### PR TITLE
feat: query defined columns

### DIFF
--- a/modules/GUI/GUI.ui
+++ b/modules/GUI/GUI.ui
@@ -1355,6 +1355,349 @@ font: 700 12pt</string>
     </widget>
    </widget>
    <widget class="QWidget" name="resultsPage">
+    <widget class="QWidget" name="addColumnPage" native="true">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="geometry">
+      <rect>
+       <x>50</x>
+       <y>110</y>
+       <width>611</width>
+       <height>421</height>
+      </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QWidget{
+	border-radius: 20px;   
+	
+	background-color: rgb(218, 218, 218);
+}</string>
+     </property>
+     <widget class="QLabel" name="addColumnLabel">
+      <property name="geometry">
+       <rect>
+        <x>30</x>
+        <y>20</y>
+        <width>121</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">font: 700 12pt;</string>
+      </property>
+      <property name="text">
+       <string>Add query column</string>
+      </property>
+     </widget>
+     <widget class="QPushButton" name="addColumnCancelButton">
+      <property name="geometry">
+       <rect>
+        <x>120</x>
+        <y>360</y>
+        <width>91</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QWidget{
+	
+	background-color: rgb(8, 144, 196);
+}
+
+QPushButton{
+	color:white;
+	font: 700 10pt;
+	border: none;
+}
+
+/*
+QPushButton:Hover{
+	background-color: rgb(56, 177, 224);
+}
+*/</string>
+      </property>
+      <property name="text">
+       <string>Cancel</string>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+      <property name="autoRepeat">
+       <bool>false</bool>
+      </property>
+      <property name="autoExclusive">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QPlainTextEdit" name="addColumnText">
+      <property name="geometry">
+       <rect>
+        <x>50</x>
+        <y>60</y>
+        <width>511</width>
+        <height>281</height>
+       </rect>
+      </property>
+      <property name="cursor" stdset="0">
+       <cursorShape>IBeamCursor</cursorShape>
+      </property>
+      <property name="mouseTracking">
+       <bool>true</bool>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QPlainTextEdit{
+	background-color: rgb(255, 255, 255);
+	font: 12pt;
+	padding-left: 10px;
+	border-radius: 20px;  
+}
+</string>
+      </property>
+      <property name="placeholderText">
+       <string>Enter prompt here...</string>
+      </property>
+     </widget>
+     <widget class="QPushButton" name="addColumnApplyButton">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>360</y>
+        <width>91</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QWidget{
+	
+	background-color: rgb(8, 144, 196);
+}
+
+QPushButton{
+	color:white;
+	font: 700 10pt;
+	border: none;
+}
+
+/*
+QPushButton:Hover{
+	background-color: rgb(56, 177, 224);
+}
+*/</string>
+      </property>
+      <property name="text">
+       <string>Apply</string>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+      <property name="autoRepeat">
+       <bool>false</bool>
+      </property>
+      <property name="autoExclusive">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </widget>
+    <widget class="QWidget" name="editColumnPage" native="true">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="geometry">
+      <rect>
+       <x>50</x>
+       <y>110</y>
+       <width>611</width>
+       <height>421</height>
+      </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QWidget{
+	border-radius: 20px;   
+	
+	background-color: rgb(218, 218, 218);
+}</string>
+     </property>
+     <widget class="QLabel" name="editColumnLabel">
+      <property name="geometry">
+       <rect>
+        <x>30</x>
+        <y>20</y>
+        <width>111</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">font: 700 12pt;</string>
+      </property>
+      <property name="text">
+       <string>Edit query column</string>
+      </property>
+     </widget>
+     <widget class="QPushButton" name="editColumnCancelButton">
+      <property name="geometry">
+       <rect>
+        <x>120</x>
+        <y>360</y>
+        <width>91</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QWidget{
+	
+	background-color: rgb(8, 144, 196);
+}
+
+QPushButton{
+	color:white;
+	font: 700 10pt;
+	border: none;
+}
+
+/*
+QPushButton:Hover{
+	background-color: rgb(56, 177, 224);
+}
+*/</string>
+      </property>
+      <property name="text">
+       <string>Cancel</string>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+      <property name="autoRepeat">
+       <bool>false</bool>
+      </property>
+      <property name="autoExclusive">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QPlainTextEdit" name="editColumnText">
+      <property name="geometry">
+       <rect>
+        <x>50</x>
+        <y>60</y>
+        <width>511</width>
+        <height>281</height>
+       </rect>
+      </property>
+      <property name="cursor" stdset="0">
+       <cursorShape>IBeamCursor</cursorShape>
+      </property>
+      <property name="mouseTracking">
+       <bool>true</bool>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QPlainTextEdit{
+	background-color: rgb(255, 255, 255);
+	font: 12pt;
+	padding-left: 10px;
+	border-radius: 20px;  
+}
+</string>
+      </property>
+      <property name="placeholderText">
+       <string>Enter prompt here...</string>
+      </property>
+     </widget>
+     <widget class="QPushButton" name="editColumnApplyButton">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>360</y>
+        <width>91</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QWidget{
+	
+	background-color: rgb(8, 144, 196);
+}
+
+QPushButton{
+	color:white;
+	font: 700 10pt;
+	border: none;
+}
+
+/*
+QPushButton:Hover{
+	background-color: rgb(56, 177, 224);
+}
+*/</string>
+      </property>
+      <property name="text">
+       <string>Apply</string>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+      <property name="autoRepeat">
+       <bool>false</bool>
+      </property>
+      <property name="autoExclusive">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QPushButton" name="deleteColumnButton">
+      <property name="geometry">
+       <rect>
+        <x>500</x>
+        <y>360</y>
+        <width>91</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QWidget{
+	
+	background-color: rgb(8, 144, 196);
+}
+
+QPushButton{
+	color:white;
+	font: 700 10pt;
+	border: none;
+}
+
+/*
+QPushButton:Hover{
+	background-color: rgb(56, 177, 224);
+}
+*/</string>
+      </property>
+      <property name="text">
+       <string>Delete column</string>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+      <property name="autoRepeat">
+       <bool>false</bool>
+      </property>
+      <property name="autoExclusive">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </widget>
     <widget class="QWidget" name="setFiltersOption" native="true">
      <property name="geometry">
       <rect>
@@ -1388,34 +1731,13 @@ font: 700 12pt</string>
 }</string>
       </property>
       <property name="text">
-       <string>Enter your Natural Language Query</string>
-      </property>
-     </widget>
-     <widget class="QLineEdit" name="searchResultsBar">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>40</y>
-        <width>411</width>
-        <height>41</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">QLineEdit{
-	background-color: rgb(255, 255, 255);
-	font: 12pt;
-	padding-left: 10px;
-}
-</string>
-      </property>
-      <property name="placeholderText">
-       <string>Find me journals relevant to...</string>
+       <string>Process articles</string>
       </property>
      </widget>
      <widget class="QPushButton" name="exportResultsButton">
       <property name="geometry">
        <rect>
-        <x>550</x>
+        <x>290</x>
         <y>40</y>
         <width>101</width>
         <height>41</height>
@@ -1490,6 +1812,82 @@ QPushButton:Checked{
        <bool>false</bool>
       </property>
      </widget>
+     <widget class="QPushButton" name="addColumnButton">
+      <property name="geometry">
+       <rect>
+        <x>180</x>
+        <y>40</y>
+        <width>101</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QPushButton{
+	color:white;
+	
+	font: 700 10pt;
+	background-color: rgb(8, 144, 196);
+}
+
+QPushButton:Checked{
+	
+	font: 8pt;
+	background-color: rgb(211, 211, 211);
+}</string>
+      </property>
+      <property name="text">
+       <string>Add column</string>
+      </property>
+      <property name="checkable">
+       <bool>false</bool>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+      <property name="autoRepeat">
+       <bool>false</bool>
+      </property>
+      <property name="autoExclusive">
+       <bool>false</bool>
+      </property>
+     </widget>
+     <widget class="QPushButton" name="downloadResultsButton">
+      <property name="geometry">
+       <rect>
+        <x>400</x>
+        <y>40</y>
+        <width>101</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QPushButton{
+            color:white;
+            font: 700 10pt;
+            background-color: rgb(8, 144, 196);
+       }
+
+       QPushButton:Checked{
+            font: 8pt;
+            background-color: rgb(211, 211, 211);
+       }</string>
+      </property>
+      <property name="text">
+       <string>Download</string>
+      </property>
+      <property name="checkable">
+       <bool>false</bool>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+      <property name="autoRepeat">
+       <bool>false</bool>
+      </property>
+      <property name="autoExclusive">
+       <bool>false</bool>
+      </property>
+     </widget>
     </widget>
     <widget class="QWidget" name="resultsList" native="true">
      <property name="geometry">
@@ -1546,26 +1944,6 @@ font: 700 12pt</string>
       <column>
        <property name="text">
         <string>PUBLICATION</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>SETTING</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>DATA</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>TARGET</string>
-       </property>
-      </column>
-      <column>
-       <property name="text">
-        <string>SYNOPSIS</string>
        </property>
       </column>
      </widget>

--- a/modules/GUI/GUI.ui
+++ b/modules/GUI/GUI.ui
@@ -281,7 +281,7 @@ QPushButton:Checked{
     <string notr="true">background-color: rgb(255, 255, 255);</string>
    </property>
    <property name="currentIndex">
-    <number>4</number>
+    <number>1</number>
    </property>
    <widget class="QWidget" name="keysPage">
     <widget class="QWidget" name="keysList" native="true">
@@ -537,11 +537,18 @@ QPushButton:Checked{
         <second>0</second>
         <year>2013</year>
         <month>12</month>
-        <day>30</day>
+        <day>31</day>
        </datetime>
       </property>
       <property name="displayFormat">
        <string>yyyy</string>
+      </property>
+      <property name="date">
+       <date>
+        <year>2013</year>
+        <month>12</month>
+        <day>31</day>
+       </date>
       </property>
      </widget>
      <widget class="QLineEdit" name="keyWords">
@@ -675,11 +682,18 @@ QPushButton:Hover{
         <second>0</second>
         <year>2023</year>
         <month>12</month>
-        <day>30</day>
+        <day>31</day>
        </datetime>
       </property>
       <property name="displayFormat">
        <string>yyyy</string>
+      </property>
+      <property name="date">
+       <date>
+        <year>2023</year>
+        <month>12</month>
+        <day>31</day>
+       </date>
       </property>
      </widget>
      <widget class="QLabel" name="publishYearToLabel">

--- a/modules/GUI/GUI.ui
+++ b/modules/GUI/GUI.ui
@@ -1374,22 +1374,6 @@ font: 700 12pt</string>
 	background-color: rgb(218, 218, 218);
 }</string>
      </property>
-     <widget class="QLabel" name="addColumnLabel">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>20</y>
-        <width>121</width>
-        <height>16</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">font: 700 12pt;</string>
-      </property>
-      <property name="text">
-       <string>Add query column</string>
-      </property>
-     </widget>
      <widget class="QPushButton" name="addColumnCancelButton">
       <property name="geometry">
        <rect>
@@ -1433,34 +1417,6 @@ QPushButton:Hover{
        <bool>true</bool>
       </property>
      </widget>
-     <widget class="QPlainTextEdit" name="addColumnText">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>60</y>
-        <width>511</width>
-        <height>281</height>
-       </rect>
-      </property>
-      <property name="cursor" stdset="0">
-       <cursorShape>IBeamCursor</cursorShape>
-      </property>
-      <property name="mouseTracking">
-       <bool>true</bool>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">QPlainTextEdit{
-	background-color: rgb(255, 255, 255);
-	font: 12pt;
-	padding-left: 10px;
-	border-radius: 20px;  
-}
-</string>
-      </property>
-      <property name="placeholderText">
-       <string>Enter prompt here...</string>
-      </property>
-     </widget>
      <widget class="QPushButton" name="addColumnApplyButton">
       <property name="geometry">
        <rect>
@@ -1502,6 +1458,103 @@ QPushButton:Hover{
       </property>
       <property name="autoExclusive">
        <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QLabel" name="addColumnLabel">
+      <property name="geometry">
+       <rect>
+        <x>30</x>
+        <y>20</y>
+        <width>111</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">font: 700 12pt;</string>
+      </property>
+      <property name="text">
+       <string>Add query column</string>
+      </property>
+     </widget>
+     <widget class="QPlainTextEdit" name="addColumnQueryText">
+      <property name="geometry">
+       <rect>
+        <x>50</x>
+        <y>160</y>
+        <width>511</width>
+        <height>181</height>
+       </rect>
+      </property>
+      <property name="cursor" stdset="0">
+       <cursorShape>IBeamCursor</cursorShape>
+      </property>
+      <property name="mouseTracking">
+       <bool>true</bool>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QPlainTextEdit{
+	background-color: rgb(255, 255, 255);
+	font: 12pt;
+	padding-left: 10px;
+	border-radius: 20px;  
+}
+</string>
+      </property>
+      <property name="placeholderText">
+       <string>Enter prompt here...</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="addColumnHeaderLabel">
+      <property name="geometry">
+       <rect>
+        <x>40</x>
+        <y>50</y>
+        <width>111</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">font: 700 12pt;</string>
+      </property>
+      <property name="text">
+       <string>Header</string>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="addColumnHeaderEntry">
+      <property name="geometry">
+       <rect>
+        <x>50</x>
+        <y>80</y>
+        <width>511</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QLineEdit{
+	background-color: rgb(255, 255, 255);
+	font: 12pt;
+	padding-left: 10px;
+}
+</string>
+      </property>
+      <property name="placeholderText">
+       <string>Enter key here...</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="addColumnQueryLabel">
+      <property name="geometry">
+       <rect>
+        <x>40</x>
+        <y>130</y>
+        <width>111</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">font: 700 12pt;</string>
+      </property>
+      <property name="text">
+       <string>Query</string>
       </property>
      </widget>
     </widget>
@@ -1583,13 +1636,13 @@ QPushButton:Hover{
        <bool>true</bool>
       </property>
      </widget>
-     <widget class="QPlainTextEdit" name="editColumnText">
+     <widget class="QPlainTextEdit" name="editColumnQueryText">
       <property name="geometry">
        <rect>
         <x>50</x>
-        <y>60</y>
+        <y>160</y>
         <width>511</width>
-        <height>281</height>
+        <height>181</height>
        </rect>
       </property>
       <property name="cursor" stdset="0">
@@ -1695,6 +1748,59 @@ QPushButton:Hover{
       </property>
       <property name="autoExclusive">
        <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="editColumnHeaderEntry">
+      <property name="geometry">
+       <rect>
+        <x>50</x>
+        <y>80</y>
+        <width>511</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QLineEdit{
+	background-color: rgb(255, 255, 255);
+	font: 12pt;
+	padding-left: 10px;
+}
+</string>
+      </property>
+      <property name="placeholderText">
+       <string>Enter key here...</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="editColumnHeaderLabel">
+      <property name="geometry">
+       <rect>
+        <x>40</x>
+        <y>50</y>
+        <width>111</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">font: 700 12pt;</string>
+      </property>
+      <property name="text">
+       <string>Header</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="editColumnQueryLabel">
+      <property name="geometry">
+       <rect>
+        <x>40</x>
+        <y>130</y>
+        <width>111</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">font: 700 12pt;</string>
+      </property>
+      <property name="text">
+       <string>Query</string>
       </property>
      </widget>
     </widget>
@@ -1948,6 +2054,10 @@ font: 700 12pt</string>
       </column>
      </widget>
     </widget>
+    <zorder>setFiltersOption</zorder>
+    <zorder>resultsList</zorder>
+    <zorder>addColumnPage</zorder>
+    <zorder>editColumnPage</zorder>
    </widget>
   </widget>
   <widget class="QPushButton" name="backButton">

--- a/modules/GUI/GUI.ui
+++ b/modules/GUI/GUI.ui
@@ -537,7 +537,7 @@ QPushButton:Checked{
         <second>0</second>
         <year>2013</year>
         <month>12</month>
-        <day>31</day>
+        <day>30</day>
        </datetime>
       </property>
       <property name="displayFormat">
@@ -675,7 +675,7 @@ QPushButton:Hover{
         <second>0</second>
         <year>2023</year>
         <month>12</month>
-        <day>31</day>
+        <day>30</day>
        </datetime>
       </property>
       <property name="displayFormat">
@@ -1840,49 +1840,10 @@ QPushButton:Hover{
        <string>Process articles</string>
       </property>
      </widget>
-     <widget class="QPushButton" name="exportResultsButton">
-      <property name="geometry">
-       <rect>
-        <x>290</x>
-        <y>40</y>
-        <width>101</width>
-        <height>41</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">QPushButton{
-	color:white;
-	
-	font: 700 10pt;
-	background-color: rgb(8, 144, 196);
-}
-
-QPushButton:Checked{
-	
-	font: 8pt;
-	background-color: rgb(211, 211, 211);
-}</string>
-      </property>
-      <property name="text">
-       <string>Export</string>
-      </property>
-      <property name="checkable">
-       <bool>false</bool>
-      </property>
-      <property name="checked">
-       <bool>false</bool>
-      </property>
-      <property name="autoRepeat">
-       <bool>false</bool>
-      </property>
-      <property name="autoExclusive">
-       <bool>false</bool>
-      </property>
-     </widget>
      <widget class="QPushButton" name="processJournalsButton">
       <property name="geometry">
        <rect>
-        <x>440</x>
+        <x>290</x>
         <y>40</y>
         <width>101</width>
         <height>41</height>
@@ -1957,7 +1918,7 @@ QPushButton:Checked{
        <bool>false</bool>
       </property>
      </widget>
-     <widget class="QPushButton" name="downloadResultsButton">
+     <widget class="QPushButton" name="exportResultsButton">
       <property name="geometry">
        <rect>
         <x>400</x>

--- a/modules/GUI/gui.py
+++ b/modules/GUI/gui.py
@@ -648,10 +648,6 @@ class Ui_Dialog(object):
 "	\n"
 "	background-color: rgb(218, 218, 218);\n"
 "}")
-        self.addColumnLabel = QLabel(self.addColumnPage)
-        self.addColumnLabel.setObjectName(u"addColumnLabel")
-        self.addColumnLabel.setGeometry(QRect(30, 20, 121, 16))
-        self.addColumnLabel.setStyleSheet(u"font: 700 12pt;")
         self.addColumnCancelButton = QPushButton(self.addColumnPage)
         self.addColumnCancelButton.setObjectName(u"addColumnCancelButton")
         self.addColumnCancelButton.setGeometry(QRect(120, 360, 91, 41))
@@ -675,18 +671,6 @@ class Ui_Dialog(object):
         self.addColumnCancelButton.setChecked(False)
         self.addColumnCancelButton.setAutoRepeat(False)
         self.addColumnCancelButton.setAutoExclusive(True)
-        self.addColumnText = QPlainTextEdit(self.addColumnPage)
-        self.addColumnText.setObjectName(u"addColumnText")
-        self.addColumnText.setGeometry(QRect(50, 60, 511, 281))
-        self.addColumnText.viewport().setProperty("cursor", QCursor(Qt.CursorShape.IBeamCursor))
-        self.addColumnText.setMouseTracking(True)
-        self.addColumnText.setStyleSheet(u"QPlainTextEdit{\n"
-"	background-color: rgb(255, 255, 255);\n"
-"	font: 12pt;\n"
-"	padding-left: 10px;\n"
-"	border-radius: 20px;  \n"
-"}\n"
-"")
         self.addColumnApplyButton = QPushButton(self.addColumnPage)
         self.addColumnApplyButton.setObjectName(u"addColumnApplyButton")
         self.addColumnApplyButton.setGeometry(QRect(20, 360, 91, 41))
@@ -710,6 +694,39 @@ class Ui_Dialog(object):
         self.addColumnApplyButton.setChecked(False)
         self.addColumnApplyButton.setAutoRepeat(False)
         self.addColumnApplyButton.setAutoExclusive(True)
+        self.addColumnLabel = QLabel(self.addColumnPage)
+        self.addColumnLabel.setObjectName(u"addColumnLabel")
+        self.addColumnLabel.setGeometry(QRect(30, 20, 111, 16))
+        self.addColumnLabel.setStyleSheet(u"font: 700 12pt;")
+        self.addColumnQueryText = QPlainTextEdit(self.addColumnPage)
+        self.addColumnQueryText.setObjectName(u"addColumnQueryText")
+        self.addColumnQueryText.setGeometry(QRect(50, 160, 511, 181))
+        self.addColumnQueryText.viewport().setProperty("cursor", QCursor(Qt.CursorShape.IBeamCursor))
+        self.addColumnQueryText.setMouseTracking(True)
+        self.addColumnQueryText.setStyleSheet(u"QPlainTextEdit{\n"
+"	background-color: rgb(255, 255, 255);\n"
+"	font: 12pt;\n"
+"	padding-left: 10px;\n"
+"	border-radius: 20px;  \n"
+"}\n"
+"")
+        self.addColumnHeaderLabel = QLabel(self.addColumnPage)
+        self.addColumnHeaderLabel.setObjectName(u"addColumnHeaderLabel")
+        self.addColumnHeaderLabel.setGeometry(QRect(40, 50, 111, 16))
+        self.addColumnHeaderLabel.setStyleSheet(u"font: 700 12pt;")
+        self.addColumnHeaderEntry = QLineEdit(self.addColumnPage)
+        self.addColumnHeaderEntry.setObjectName(u"addColumnHeaderEntry")
+        self.addColumnHeaderEntry.setGeometry(QRect(50, 80, 511, 41))
+        self.addColumnHeaderEntry.setStyleSheet(u"QLineEdit{\n"
+"	background-color: rgb(255, 255, 255);\n"
+"	font: 12pt;\n"
+"	padding-left: 10px;\n"
+"}\n"
+"")
+        self.addColumnQueryLabel = QLabel(self.addColumnPage)
+        self.addColumnQueryLabel.setObjectName(u"addColumnQueryLabel")
+        self.addColumnQueryLabel.setGeometry(QRect(40, 130, 111, 16))
+        self.addColumnQueryLabel.setStyleSheet(u"font: 700 12pt;")
         self.editColumnPage = QWidget(self.resultsPage)
         self.editColumnPage.setObjectName(u"editColumnPage")
         self.editColumnPage.setEnabled(True)
@@ -746,12 +763,12 @@ class Ui_Dialog(object):
         self.editColumnCancelButton.setChecked(False)
         self.editColumnCancelButton.setAutoRepeat(False)
         self.editColumnCancelButton.setAutoExclusive(True)
-        self.editColumnText = QPlainTextEdit(self.editColumnPage)
-        self.editColumnText.setObjectName(u"editColumnText")
-        self.editColumnText.setGeometry(QRect(50, 60, 511, 281))
-        self.editColumnText.viewport().setProperty("cursor", QCursor(Qt.CursorShape.IBeamCursor))
-        self.editColumnText.setMouseTracking(True)
-        self.editColumnText.setStyleSheet(u"QPlainTextEdit{\n"
+        self.editColumnQueryText = QPlainTextEdit(self.editColumnPage)
+        self.editColumnQueryText.setObjectName(u"editColumnQueryText")
+        self.editColumnQueryText.setGeometry(QRect(50, 160, 511, 181))
+        self.editColumnQueryText.viewport().setProperty("cursor", QCursor(Qt.CursorShape.IBeamCursor))
+        self.editColumnQueryText.setMouseTracking(True)
+        self.editColumnQueryText.setStyleSheet(u"QPlainTextEdit{\n"
 "	background-color: rgb(255, 255, 255);\n"
 "	font: 12pt;\n"
 "	padding-left: 10px;\n"
@@ -804,6 +821,23 @@ class Ui_Dialog(object):
         self.deleteColumnButton.setChecked(False)
         self.deleteColumnButton.setAutoRepeat(False)
         self.deleteColumnButton.setAutoExclusive(True)
+        self.editColumnHeaderEntry = QLineEdit(self.editColumnPage)
+        self.editColumnHeaderEntry.setObjectName(u"editColumnHeaderEntry")
+        self.editColumnHeaderEntry.setGeometry(QRect(50, 80, 511, 41))
+        self.editColumnHeaderEntry.setStyleSheet(u"QLineEdit{\n"
+"	background-color: rgb(255, 255, 255);\n"
+"	font: 12pt;\n"
+"	padding-left: 10px;\n"
+"}\n"
+"")
+        self.editColumnHeaderLabel = QLabel(self.editColumnPage)
+        self.editColumnHeaderLabel.setObjectName(u"editColumnHeaderLabel")
+        self.editColumnHeaderLabel.setGeometry(QRect(40, 50, 111, 16))
+        self.editColumnHeaderLabel.setStyleSheet(u"font: 700 12pt;")
+        self.editColumnQueryLabel = QLabel(self.editColumnPage)
+        self.editColumnQueryLabel.setObjectName(u"editColumnQueryLabel")
+        self.editColumnQueryLabel.setGeometry(QRect(40, 130, 111, 16))
+        self.editColumnQueryLabel.setStyleSheet(u"font: 700 12pt;")
         self.setFiltersOption = QWidget(self.resultsPage)
         self.setFiltersOption.setObjectName(u"setFiltersOption")
         self.setFiltersOption.setGeometry(QRect(20, 20, 671, 101))
@@ -923,6 +957,10 @@ class Ui_Dialog(object):
 "}\n"
 "font: 700 12pt")
         self.myQStackedWidget.addWidget(self.resultsPage)
+        self.setFiltersOption.raise_()
+        self.resultsList.raise_()
+        self.addColumnPage.raise_()
+        self.editColumnPage.raise_()
         self.backButton = QPushButton(Dialog)
         self.backButton.setObjectName(u"backButton")
         self.backButton.setEnabled(True)
@@ -1022,15 +1060,21 @@ class Ui_Dialog(object):
         ___qtablewidgetitem6.setText(QCoreApplication.translate("Dialog", u"TYPE", None));
         ___qtablewidgetitem7 = self.journalListTableWidget.horizontalHeaderItem(3)
         ___qtablewidgetitem7.setText(QCoreApplication.translate("Dialog", u"DATE", None));
-        self.addColumnLabel.setText(QCoreApplication.translate("Dialog", u"Add query column", None))
         self.addColumnCancelButton.setText(QCoreApplication.translate("Dialog", u"Cancel", None))
-        self.addColumnText.setPlaceholderText(QCoreApplication.translate("Dialog", u"Enter prompt here...", None))
         self.addColumnApplyButton.setText(QCoreApplication.translate("Dialog", u"Apply", None))
+        self.addColumnLabel.setText(QCoreApplication.translate("Dialog", u"Add query column", None))
+        self.addColumnQueryText.setPlaceholderText(QCoreApplication.translate("Dialog", u"Enter prompt here...", None))
+        self.addColumnHeaderLabel.setText(QCoreApplication.translate("Dialog", u"Header", None))
+        self.addColumnHeaderEntry.setPlaceholderText(QCoreApplication.translate("Dialog", u"Enter key here...", None))
+        self.addColumnQueryLabel.setText(QCoreApplication.translate("Dialog", u"Query", None))
         self.editColumnLabel.setText(QCoreApplication.translate("Dialog", u"Edit query column", None))
         self.editColumnCancelButton.setText(QCoreApplication.translate("Dialog", u"Cancel", None))
-        self.editColumnText.setPlaceholderText(QCoreApplication.translate("Dialog", u"Enter prompt here...", None))
+        self.editColumnQueryText.setPlaceholderText(QCoreApplication.translate("Dialog", u"Enter prompt here...", None))
         self.editColumnApplyButton.setText(QCoreApplication.translate("Dialog", u"Apply", None))
         self.deleteColumnButton.setText(QCoreApplication.translate("Dialog", u"Delete column", None))
+        self.editColumnHeaderEntry.setPlaceholderText(QCoreApplication.translate("Dialog", u"Enter key here...", None))
+        self.editColumnHeaderLabel.setText(QCoreApplication.translate("Dialog", u"Header", None))
+        self.editColumnQueryLabel.setText(QCoreApplication.translate("Dialog", u"Query", None))
         self.searchResultsTag.setText(QCoreApplication.translate("Dialog", u"Process articles", None))
         self.exportResultsButton.setText(QCoreApplication.translate("Dialog", u"Export", None))
         self.processJournalsButton.setText(QCoreApplication.translate("Dialog", u"Process", None))

--- a/modules/GUI/gui.py
+++ b/modules/GUI/gui.py
@@ -16,8 +16,9 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
 from PySide6.QtWidgets import (QApplication, QDateEdit, QDialog, QHeaderView,
-    QLabel, QLineEdit, QPushButton, QSizePolicy,
-    QStackedWidget, QTableWidget, QTableWidgetItem, QWidget)
+    QLabel, QLineEdit, QPlainTextEdit, QPushButton,
+    QSizePolicy, QStackedWidget, QTableWidget, QTableWidgetItem,
+    QWidget)
 
 class Ui_Dialog(object):
     def setupUi(self, Dialog):
@@ -638,6 +639,171 @@ class Ui_Dialog(object):
         self.myQStackedWidget.addWidget(self.uploadJournalPage)
         self.resultsPage = QWidget()
         self.resultsPage.setObjectName(u"resultsPage")
+        self.addColumnPage = QWidget(self.resultsPage)
+        self.addColumnPage.setObjectName(u"addColumnPage")
+        self.addColumnPage.setEnabled(True)
+        self.addColumnPage.setGeometry(QRect(50, 110, 611, 421))
+        self.addColumnPage.setStyleSheet(u"QWidget{\n"
+"	border-radius: 20px;   \n"
+"	\n"
+"	background-color: rgb(218, 218, 218);\n"
+"}")
+        self.addColumnLabel = QLabel(self.addColumnPage)
+        self.addColumnLabel.setObjectName(u"addColumnLabel")
+        self.addColumnLabel.setGeometry(QRect(30, 20, 121, 16))
+        self.addColumnLabel.setStyleSheet(u"font: 700 12pt;")
+        self.addColumnCancelButton = QPushButton(self.addColumnPage)
+        self.addColumnCancelButton.setObjectName(u"addColumnCancelButton")
+        self.addColumnCancelButton.setGeometry(QRect(120, 360, 91, 41))
+        self.addColumnCancelButton.setStyleSheet(u"QWidget{\n"
+"	\n"
+"	background-color: rgb(8, 144, 196);\n"
+"}\n"
+"\n"
+"QPushButton{\n"
+"	color:white;\n"
+"	font: 700 10pt;\n"
+"	border: none;\n"
+"}\n"
+"\n"
+"/*\n"
+"QPushButton:Hover{\n"
+"	background-color: rgb(56, 177, 224);\n"
+"}\n"
+"*/")
+        self.addColumnCancelButton.setCheckable(True)
+        self.addColumnCancelButton.setChecked(False)
+        self.addColumnCancelButton.setAutoRepeat(False)
+        self.addColumnCancelButton.setAutoExclusive(True)
+        self.addColumnText = QPlainTextEdit(self.addColumnPage)
+        self.addColumnText.setObjectName(u"addColumnText")
+        self.addColumnText.setGeometry(QRect(50, 60, 511, 281))
+        self.addColumnText.viewport().setProperty("cursor", QCursor(Qt.CursorShape.IBeamCursor))
+        self.addColumnText.setMouseTracking(True)
+        self.addColumnText.setStyleSheet(u"QPlainTextEdit{\n"
+"	background-color: rgb(255, 255, 255);\n"
+"	font: 12pt;\n"
+"	padding-left: 10px;\n"
+"	border-radius: 20px;  \n"
+"}\n"
+"")
+        self.addColumnApplyButton = QPushButton(self.addColumnPage)
+        self.addColumnApplyButton.setObjectName(u"addColumnApplyButton")
+        self.addColumnApplyButton.setGeometry(QRect(20, 360, 91, 41))
+        self.addColumnApplyButton.setStyleSheet(u"QWidget{\n"
+"	\n"
+"	background-color: rgb(8, 144, 196);\n"
+"}\n"
+"\n"
+"QPushButton{\n"
+"	color:white;\n"
+"	font: 700 10pt;\n"
+"	border: none;\n"
+"}\n"
+"\n"
+"/*\n"
+"QPushButton:Hover{\n"
+"	background-color: rgb(56, 177, 224);\n"
+"}\n"
+"*/")
+        self.addColumnApplyButton.setCheckable(True)
+        self.addColumnApplyButton.setChecked(False)
+        self.addColumnApplyButton.setAutoRepeat(False)
+        self.addColumnApplyButton.setAutoExclusive(True)
+        self.editColumnPage = QWidget(self.resultsPage)
+        self.editColumnPage.setObjectName(u"editColumnPage")
+        self.editColumnPage.setEnabled(True)
+        self.editColumnPage.setGeometry(QRect(50, 110, 611, 421))
+        self.editColumnPage.setStyleSheet(u"QWidget{\n"
+"	border-radius: 20px;   \n"
+"	\n"
+"	background-color: rgb(218, 218, 218);\n"
+"}")
+        self.editColumnLabel = QLabel(self.editColumnPage)
+        self.editColumnLabel.setObjectName(u"editColumnLabel")
+        self.editColumnLabel.setGeometry(QRect(30, 20, 111, 16))
+        self.editColumnLabel.setStyleSheet(u"font: 700 12pt;")
+        self.editColumnCancelButton = QPushButton(self.editColumnPage)
+        self.editColumnCancelButton.setObjectName(u"editColumnCancelButton")
+        self.editColumnCancelButton.setGeometry(QRect(120, 360, 91, 41))
+        self.editColumnCancelButton.setStyleSheet(u"QWidget{\n"
+"	\n"
+"	background-color: rgb(8, 144, 196);\n"
+"}\n"
+"\n"
+"QPushButton{\n"
+"	color:white;\n"
+"	font: 700 10pt;\n"
+"	border: none;\n"
+"}\n"
+"\n"
+"/*\n"
+"QPushButton:Hover{\n"
+"	background-color: rgb(56, 177, 224);\n"
+"}\n"
+"*/")
+        self.editColumnCancelButton.setCheckable(True)
+        self.editColumnCancelButton.setChecked(False)
+        self.editColumnCancelButton.setAutoRepeat(False)
+        self.editColumnCancelButton.setAutoExclusive(True)
+        self.editColumnText = QPlainTextEdit(self.editColumnPage)
+        self.editColumnText.setObjectName(u"editColumnText")
+        self.editColumnText.setGeometry(QRect(50, 60, 511, 281))
+        self.editColumnText.viewport().setProperty("cursor", QCursor(Qt.CursorShape.IBeamCursor))
+        self.editColumnText.setMouseTracking(True)
+        self.editColumnText.setStyleSheet(u"QPlainTextEdit{\n"
+"	background-color: rgb(255, 255, 255);\n"
+"	font: 12pt;\n"
+"	padding-left: 10px;\n"
+"	border-radius: 20px;  \n"
+"}\n"
+"")
+        self.editColumnApplyButton = QPushButton(self.editColumnPage)
+        self.editColumnApplyButton.setObjectName(u"editColumnApplyButton")
+        self.editColumnApplyButton.setGeometry(QRect(20, 360, 91, 41))
+        self.editColumnApplyButton.setStyleSheet(u"QWidget{\n"
+"	\n"
+"	background-color: rgb(8, 144, 196);\n"
+"}\n"
+"\n"
+"QPushButton{\n"
+"	color:white;\n"
+"	font: 700 10pt;\n"
+"	border: none;\n"
+"}\n"
+"\n"
+"/*\n"
+"QPushButton:Hover{\n"
+"	background-color: rgb(56, 177, 224);\n"
+"}\n"
+"*/")
+        self.editColumnApplyButton.setCheckable(True)
+        self.editColumnApplyButton.setChecked(False)
+        self.editColumnApplyButton.setAutoRepeat(False)
+        self.editColumnApplyButton.setAutoExclusive(True)
+        self.deleteColumnButton = QPushButton(self.editColumnPage)
+        self.deleteColumnButton.setObjectName(u"deleteColumnButton")
+        self.deleteColumnButton.setGeometry(QRect(500, 360, 91, 41))
+        self.deleteColumnButton.setStyleSheet(u"QWidget{\n"
+"	\n"
+"	background-color: rgb(8, 144, 196);\n"
+"}\n"
+"\n"
+"QPushButton{\n"
+"	color:white;\n"
+"	font: 700 10pt;\n"
+"	border: none;\n"
+"}\n"
+"\n"
+"/*\n"
+"QPushButton:Hover{\n"
+"	background-color: rgb(56, 177, 224);\n"
+"}\n"
+"*/")
+        self.deleteColumnButton.setCheckable(True)
+        self.deleteColumnButton.setChecked(False)
+        self.deleteColumnButton.setAutoRepeat(False)
+        self.deleteColumnButton.setAutoExclusive(True)
         self.setFiltersOption = QWidget(self.resultsPage)
         self.setFiltersOption.setObjectName(u"setFiltersOption")
         self.setFiltersOption.setGeometry(QRect(20, 20, 671, 101))
@@ -654,18 +820,9 @@ class Ui_Dialog(object):
 "	font: 700 12pt\n"
 "	\n"
 "}")
-        self.searchResultsBar = QLineEdit(self.setFiltersOption)
-        self.searchResultsBar.setObjectName(u"searchResultsBar")
-        self.searchResultsBar.setGeometry(QRect(20, 40, 411, 41))
-        self.searchResultsBar.setStyleSheet(u"QLineEdit{\n"
-"	background-color: rgb(255, 255, 255);\n"
-"	font: 12pt;\n"
-"	padding-left: 10px;\n"
-"}\n"
-"")
         self.exportResultsButton = QPushButton(self.setFiltersOption)
         self.exportResultsButton.setObjectName(u"exportResultsButton")
-        self.exportResultsButton.setGeometry(QRect(550, 40, 101, 41))
+        self.exportResultsButton.setGeometry(QRect(290, 40, 101, 41))
         self.exportResultsButton.setStyleSheet(u"QPushButton{\n"
 "	color:white;\n"
 "	\n"
@@ -701,6 +858,42 @@ class Ui_Dialog(object):
         self.processJournalsButton.setChecked(False)
         self.processJournalsButton.setAutoRepeat(False)
         self.processJournalsButton.setAutoExclusive(False)
+        self.addColumnButton = QPushButton(self.setFiltersOption)
+        self.addColumnButton.setObjectName(u"addColumnButton")
+        self.addColumnButton.setGeometry(QRect(180, 40, 101, 41))
+        self.addColumnButton.setStyleSheet(u"QPushButton{\n"
+"	color:white;\n"
+"	\n"
+"	font: 700 10pt;\n"
+"	background-color: rgb(8, 144, 196);\n"
+"}\n"
+"\n"
+"QPushButton:Checked{\n"
+"	\n"
+"	font: 8pt;\n"
+"	background-color: rgb(211, 211, 211);\n"
+"}")
+        self.addColumnButton.setCheckable(False)
+        self.addColumnButton.setChecked(False)
+        self.addColumnButton.setAutoRepeat(False)
+        self.addColumnButton.setAutoExclusive(False)
+        self.downloadResultsButton = QPushButton(self.setFiltersOption)
+        self.downloadResultsButton.setObjectName(u"downloadResultsButton")
+        self.downloadResultsButton.setGeometry(QRect(400, 40, 101, 41))
+        self.downloadResultsButton.setStyleSheet(u"QPushButton{\n"
+"            color:white;\n"
+"            font: 700 10pt;\n"
+"            background-color: rgb(8, 144, 196);\n"
+"       }\n"
+"\n"
+"       QPushButton:Checked{\n"
+"            font: 8pt;\n"
+"            background-color: rgb(211, 211, 211);\n"
+"       }")
+        self.downloadResultsButton.setCheckable(False)
+        self.downloadResultsButton.setChecked(False)
+        self.downloadResultsButton.setAutoRepeat(False)
+        self.downloadResultsButton.setAutoExclusive(False)
         self.resultsList = QWidget(self.resultsPage)
         self.resultsList.setObjectName(u"resultsList")
         self.resultsList.setGeometry(QRect(20, 140, 671, 371))
@@ -719,18 +912,10 @@ class Ui_Dialog(object):
 "	\n"
 "}")
         self.resultsListTableWidget = QTableWidget(self.resultsList)
-        if (self.resultsListTableWidget.columnCount() < 5):
-            self.resultsListTableWidget.setColumnCount(5)
+        if (self.resultsListTableWidget.columnCount() < 1):
+            self.resultsListTableWidget.setColumnCount(1)
         __qtablewidgetitem8 = QTableWidgetItem()
         self.resultsListTableWidget.setHorizontalHeaderItem(0, __qtablewidgetitem8)
-        __qtablewidgetitem9 = QTableWidgetItem()
-        self.resultsListTableWidget.setHorizontalHeaderItem(1, __qtablewidgetitem9)
-        __qtablewidgetitem10 = QTableWidgetItem()
-        self.resultsListTableWidget.setHorizontalHeaderItem(2, __qtablewidgetitem10)
-        __qtablewidgetitem11 = QTableWidgetItem()
-        self.resultsListTableWidget.setHorizontalHeaderItem(3, __qtablewidgetitem11)
-        __qtablewidgetitem12 = QTableWidgetItem()
-        self.resultsListTableWidget.setHorizontalHeaderItem(4, __qtablewidgetitem12)
         self.resultsListTableWidget.setObjectName(u"resultsListTableWidget")
         self.resultsListTableWidget.setGeometry(QRect(30, 50, 621, 301))
         self.resultsListTableWidget.setStyleSheet(u"QHeaderView::section {\n"
@@ -837,21 +1022,23 @@ class Ui_Dialog(object):
         ___qtablewidgetitem6.setText(QCoreApplication.translate("Dialog", u"TYPE", None));
         ___qtablewidgetitem7 = self.journalListTableWidget.horizontalHeaderItem(3)
         ___qtablewidgetitem7.setText(QCoreApplication.translate("Dialog", u"DATE", None));
-        self.searchResultsTag.setText(QCoreApplication.translate("Dialog", u"Enter your Natural Language Query", None))
-        self.searchResultsBar.setPlaceholderText(QCoreApplication.translate("Dialog", u"Find me journals relevant to...", None))
+        self.addColumnLabel.setText(QCoreApplication.translate("Dialog", u"Add query column", None))
+        self.addColumnCancelButton.setText(QCoreApplication.translate("Dialog", u"Cancel", None))
+        self.addColumnText.setPlaceholderText(QCoreApplication.translate("Dialog", u"Enter prompt here...", None))
+        self.addColumnApplyButton.setText(QCoreApplication.translate("Dialog", u"Apply", None))
+        self.editColumnLabel.setText(QCoreApplication.translate("Dialog", u"Edit query column", None))
+        self.editColumnCancelButton.setText(QCoreApplication.translate("Dialog", u"Cancel", None))
+        self.editColumnText.setPlaceholderText(QCoreApplication.translate("Dialog", u"Enter prompt here...", None))
+        self.editColumnApplyButton.setText(QCoreApplication.translate("Dialog", u"Apply", None))
+        self.deleteColumnButton.setText(QCoreApplication.translate("Dialog", u"Delete column", None))
+        self.searchResultsTag.setText(QCoreApplication.translate("Dialog", u"Process articles", None))
         self.exportResultsButton.setText(QCoreApplication.translate("Dialog", u"Export", None))
         self.processJournalsButton.setText(QCoreApplication.translate("Dialog", u"Process", None))
+        self.addColumnButton.setText(QCoreApplication.translate("Dialog", u"Add column", None))
+        self.downloadResultsButton.setText(QCoreApplication.translate("Dialog", u"Download", None))
         self.resultsListTag.setText(QCoreApplication.translate("Dialog", u"Results", None))
         ___qtablewidgetitem8 = self.resultsListTableWidget.horizontalHeaderItem(0)
         ___qtablewidgetitem8.setText(QCoreApplication.translate("Dialog", u"PUBLICATION", None));
-        ___qtablewidgetitem9 = self.resultsListTableWidget.horizontalHeaderItem(1)
-        ___qtablewidgetitem9.setText(QCoreApplication.translate("Dialog", u"SETTING", None));
-        ___qtablewidgetitem10 = self.resultsListTableWidget.horizontalHeaderItem(2)
-        ___qtablewidgetitem10.setText(QCoreApplication.translate("Dialog", u"DATA", None));
-        ___qtablewidgetitem11 = self.resultsListTableWidget.horizontalHeaderItem(3)
-        ___qtablewidgetitem11.setText(QCoreApplication.translate("Dialog", u"TARGET", None));
-        ___qtablewidgetitem12 = self.resultsListTableWidget.horizontalHeaderItem(4)
-        ___qtablewidgetitem12.setText(QCoreApplication.translate("Dialog", u"SYNOPSIS", None));
         self.backButton.setText(QCoreApplication.translate("Dialog", u"Back", None))
         self.nextButton.setText(QCoreApplication.translate("Dialog", u"Next", None))
     # retranslateUi

--- a/modules/GUI/gui.py
+++ b/modules/GUI/gui.py
@@ -266,7 +266,7 @@ class Ui_Dialog(object):
 "	\n"
 "	background-color: rgb(255, 255, 255);\n"
 "}")
-        self.publishYearFrom.setDateTime(QDateTime(QDate(2013, 12, 31), QTime(0, 0, 0)))
+        self.publishYearFrom.setDateTime(QDateTime(QDate(2013, 12, 30), QTime(0, 0, 0)))
         self.keyWords = QLineEdit(self.setFiltersPage)
         self.keyWords.setObjectName(u"keyWords")
         self.keyWords.setGeometry(QRect(50, 140, 301, 41))
@@ -321,7 +321,7 @@ class Ui_Dialog(object):
 "	\n"
 "	background-color: rgb(255, 255, 255);\n"
 "}")
-        self.publishYearTo.setDateTime(QDateTime(QDate(2023, 12, 31), QTime(0, 0, 0)))
+        self.publishYearTo.setDateTime(QDateTime(QDate(2023, 12, 30), QTime(0, 0, 0)))
         self.publishYearToLabel = QLabel(self.setFiltersPage)
         self.publishYearToLabel.setObjectName(u"publishYearToLabel")
         self.publishYearToLabel.setGeometry(QRect(410, 110, 41, 20))
@@ -854,28 +854,9 @@ class Ui_Dialog(object):
 "	font: 700 12pt\n"
 "	\n"
 "}")
-        self.exportResultsButton = QPushButton(self.setFiltersOption)
-        self.exportResultsButton.setObjectName(u"exportResultsButton")
-        self.exportResultsButton.setGeometry(QRect(290, 40, 101, 41))
-        self.exportResultsButton.setStyleSheet(u"QPushButton{\n"
-"	color:white;\n"
-"	\n"
-"	font: 700 10pt;\n"
-"	background-color: rgb(8, 144, 196);\n"
-"}\n"
-"\n"
-"QPushButton:Checked{\n"
-"	\n"
-"	font: 8pt;\n"
-"	background-color: rgb(211, 211, 211);\n"
-"}")
-        self.exportResultsButton.setCheckable(False)
-        self.exportResultsButton.setChecked(False)
-        self.exportResultsButton.setAutoRepeat(False)
-        self.exportResultsButton.setAutoExclusive(False)
         self.processJournalsButton = QPushButton(self.setFiltersOption)
         self.processJournalsButton.setObjectName(u"processJournalsButton")
-        self.processJournalsButton.setGeometry(QRect(440, 40, 101, 41))
+        self.processJournalsButton.setGeometry(QRect(290, 40, 101, 41))
         self.processJournalsButton.setStyleSheet(u"QPushButton{\n"
 "	color:white;\n"
 "	\n"
@@ -911,10 +892,10 @@ class Ui_Dialog(object):
         self.addColumnButton.setChecked(False)
         self.addColumnButton.setAutoRepeat(False)
         self.addColumnButton.setAutoExclusive(False)
-        self.downloadResultsButton = QPushButton(self.setFiltersOption)
-        self.downloadResultsButton.setObjectName(u"downloadResultsButton")
-        self.downloadResultsButton.setGeometry(QRect(400, 40, 101, 41))
-        self.downloadResultsButton.setStyleSheet(u"QPushButton{\n"
+        self.exportResultsButton = QPushButton(self.setFiltersOption)
+        self.exportResultsButton.setObjectName(u"exportResultsButton")
+        self.exportResultsButton.setGeometry(QRect(400, 40, 101, 41))
+        self.exportResultsButton.setStyleSheet(u"QPushButton{\n"
 "            color:white;\n"
 "            font: 700 10pt;\n"
 "            background-color: rgb(8, 144, 196);\n"
@@ -924,10 +905,10 @@ class Ui_Dialog(object):
 "            font: 8pt;\n"
 "            background-color: rgb(211, 211, 211);\n"
 "       }")
-        self.downloadResultsButton.setCheckable(False)
-        self.downloadResultsButton.setChecked(False)
-        self.downloadResultsButton.setAutoRepeat(False)
-        self.downloadResultsButton.setAutoExclusive(False)
+        self.exportResultsButton.setCheckable(False)
+        self.exportResultsButton.setChecked(False)
+        self.exportResultsButton.setAutoRepeat(False)
+        self.exportResultsButton.setAutoExclusive(False)
         self.resultsList = QWidget(self.resultsPage)
         self.resultsList.setObjectName(u"resultsList")
         self.resultsList.setGeometry(QRect(20, 140, 671, 371))
@@ -1076,10 +1057,9 @@ class Ui_Dialog(object):
         self.editColumnHeaderLabel.setText(QCoreApplication.translate("Dialog", u"Header", None))
         self.editColumnQueryLabel.setText(QCoreApplication.translate("Dialog", u"Query", None))
         self.searchResultsTag.setText(QCoreApplication.translate("Dialog", u"Process articles", None))
-        self.exportResultsButton.setText(QCoreApplication.translate("Dialog", u"Export", None))
         self.processJournalsButton.setText(QCoreApplication.translate("Dialog", u"Process", None))
         self.addColumnButton.setText(QCoreApplication.translate("Dialog", u"Add column", None))
-        self.downloadResultsButton.setText(QCoreApplication.translate("Dialog", u"Download", None))
+        self.exportResultsButton.setText(QCoreApplication.translate("Dialog", u"Download", None))
         self.resultsListTag.setText(QCoreApplication.translate("Dialog", u"Results", None))
         ___qtablewidgetitem8 = self.resultsListTableWidget.horizontalHeaderItem(0)
         ___qtablewidgetitem8.setText(QCoreApplication.translate("Dialog", u"PUBLICATION", None));

--- a/modules/GUI/gui.py
+++ b/modules/GUI/gui.py
@@ -266,7 +266,8 @@ class Ui_Dialog(object):
 "	\n"
 "	background-color: rgb(255, 255, 255);\n"
 "}")
-        self.publishYearFrom.setDateTime(QDateTime(QDate(2013, 12, 30), QTime(0, 0, 0)))
+        self.publishYearFrom.setDateTime(QDateTime(QDate(2013, 12, 31), QTime(0, 0, 0)))
+        self.publishYearFrom.setDate(QDate(2013, 12, 31))
         self.keyWords = QLineEdit(self.setFiltersPage)
         self.keyWords.setObjectName(u"keyWords")
         self.keyWords.setGeometry(QRect(50, 140, 301, 41))
@@ -321,7 +322,8 @@ class Ui_Dialog(object):
 "	\n"
 "	background-color: rgb(255, 255, 255);\n"
 "}")
-        self.publishYearTo.setDateTime(QDateTime(QDate(2023, 12, 30), QTime(0, 0, 0)))
+        self.publishYearTo.setDateTime(QDateTime(QDate(2023, 12, 31), QTime(0, 0, 0)))
+        self.publishYearTo.setDate(QDate(2023, 12, 31))
         self.publishYearToLabel = QLabel(self.setFiltersPage)
         self.publishYearToLabel.setObjectName(u"publishYearToLabel")
         self.publishYearToLabel.setGeometry(QRect(410, 110, 41, 20))
@@ -974,7 +976,7 @@ class Ui_Dialog(object):
 
         self.retranslateUi(Dialog)
 
-        self.myQStackedWidget.setCurrentIndex(4)
+        self.myQStackedWidget.setCurrentIndex(1)
 
 
         QMetaObject.connectSlotsByName(Dialog)

--- a/modules/exporter/columns.json
+++ b/modules/exporter/columns.json
@@ -1,0 +1,17 @@
+{
+    "columns": [
+        {
+            "header": "Setting",
+            "query": "Can you say a single country to describe the setting the journal is analyzing? Say nothing else except the country."},
+        {
+            "header": "Type",
+            "query": "Can you say a maximum of 6 words to describe the type of data the journal is analyzing? Say nothing except the data type."},
+        {
+            "header": "Population",
+            "query": "Can you say a maximum of 6 words to describe the target population the journal is analyzing? Say nothing except the target population."},
+        {
+            "header": "Summary",
+            "query": "Can you summarize the journal in a paragraph? Say nothing except the paragraph."
+        }
+    ]
+}

--- a/road_safety_scanner.py
+++ b/road_safety_scanner.py
@@ -1,9 +1,10 @@
 """Main application file for the Road Safety Scanner application."""
 import json
 import sys
-from typing import Any, Self
+from typing import Any, Callable, Self
 
 from PySide6.QtCore import Qt
+from PySide6.QtGui import QMouseEvent, QPainter, QRect
 from PySide6.QtWidgets import (
     QApplication,
     QFileDialog,
@@ -11,6 +12,7 @@ from PySide6.QtWidgets import (
     QMainWindow,
     QProgressDialog,
     QTableWidgetItem,
+    QWidget,
 )
 
 from modules.exporter import exportToExcel, journal_responses_to_data_frame
@@ -30,18 +32,25 @@ from modules.llm.gpt.query import (
 
 
 class ResultsTableHeader(QHeaderView):
-    def __init__(self, orientation, parent, onClicked = lambda: None):
+    """Custom header class for the results table."""
+
+    def __init__(self: Self, orientation: Qt.Orientation, parent: QWidget,
+                 on_clicked:Callable[[int], None] = lambda: None) -> None:
+        """Initialize the custom header."""
         super().__init__(orientation, parent)
         self.setSectionsClickable(True)
 
-        self.onClicked = onClicked
+        self.on_clicked = on_clicked
 
-    def paintSection(self, painter, rect, logicalIndex):
-        super().paintSection(painter, rect, logicalIndex)
+    def paintSection(self: Self, painter: QPainter, rect: QRect, # noqa: N802
+                     logical_index: int) -> None: 
+        """Paint the section of the header."""
+        super().paintSection(painter, rect, logical_index)
 
-    def mouseReleaseEvent(self, event):
+    def mouseReleaseEvent(self: Self, event: QMouseEvent) -> None: # noqa: N802
+        """Handle the mouse release event."""
         super().mouseReleaseEvent(event)
-        self.onClicked(self.logicalIndexAt(event.position().toPoint()))
+        self.on_clicked(self.logicalIndexAt(event.position().toPoint()))
 
 class MainWindow(QMainWindow):
     """Main window class for the Road Safety Scanner application."""
@@ -64,32 +73,44 @@ class MainWindow(QMainWindow):
             4: self.ui.resultsButton
         }
 
-        self.ui.resultsListTableWidget.setHorizontalHeader(ResultsTableHeader(Qt.Horizontal, self.ui.resultsListTableWidget, self.openEditColumn))
+        self.ui.resultsListTableWidget.setHorizontalHeader(
+            ResultsTableHeader(
+                Qt.Horizontal,
+                self.ui.resultsListTableWidget,
+                self.open_edit_column))
 
         # Set the Search Page as the default start up page
         self.switch_to_page(1)
 
         # Hide Filter Page
         self.ui.setFiltersPage.setVisible(False)
-        self.ui.setFiltersCloseButton.clicked.connect(lambda: self.ui.setFiltersPage.setVisible(not self.ui.addColumnPage.isVisible()))
+        self.ui.setFiltersCloseButton.clicked.connect(
+            lambda:self.ui.setFiltersPage.setVisible(
+                not self.ui.addColumnPage.isVisible()))
 
         # Setup Add Column Page Modal
         self.ui.addColumnPage.setVisible(False)
-        self.ui.addColumnButton.clicked.connect(lambda: self.closeAddColumn() if self.ui.addColumnPage.isVisible() else self.ui.addColumnPage.setVisible(True))
-        self.ui.addColumnCancelButton.clicked.connect(self.closeAddColumn)
-        self.ui.addColumnApplyButton.clicked.connect(self.addColumn)
+        self.ui.addColumnButton.clicked.connect(
+            lambda: self.close_add_column()
+            if self.ui.addColumnPage.isVisible()
+            else self.ui.addColumnPage.setVisible(True))
+        self.ui.addColumnCancelButton.clicked.connect(self.close_add_column)
+        self.ui.addColumnApplyButton.clicked.connect(self.add_column)
 
         # Setup Edit Column Page Modal
         self.ui.editColumnPage.setVisible(False)
-        self.ui.editColumnCancelButton.clicked.connect(self.closeEditColumn)
-        self.ui.editColumnApplyButton.clicked.connect(self.editColumn)
-        self.ui.deleteColumnButton.clicked.connect(lambda: self.deleteColumn(self.editingColumn))
+        self.ui.editColumnCancelButton.clicked.connect(self.close_edit_column)
+        self.ui.editColumnApplyButton.clicked.connect(self.edit_column)
+        self.ui.deleteColumnButton.clicked.connect(
+            lambda: self.delete_column(self.editingColumn))
 
         # Setup the columns for the results table
         self.publicationColumns = ["Publication"]
-        rawColumns = json.loads(open("modules/exporter/columns.json").read())["columns"]
-        self.queryColumns = [(column["header"], column["query"]) for column in rawColumns]
-        self.buildResultsTable()
+        with open("modules/exporter/columns.json") as columns_file:
+            raw_columns = json.loads(columns_file.read())["columns"]
+            self.queryColumns = [(column["header"], column["query"])
+                                 for column in raw_columns]
+        self.build_results_table()
 
         # Connect menu buttons to their respective functions
         self.ui.keysButton.clicked.connect(lambda: self.switch_to_page(0))
@@ -314,82 +335,95 @@ class MainWindow(QMainWindow):
             row_position = self.ui.journalListTableWidget.rowCount()
             self.ui.journalListTableWidget.insertRow(row_position)
 
-    def buildResultsTable(self):
+            joined_authors = ", ".join([author["$"] for author in authors])
+            self.ui.journalListTableWidget.setItem(row_position, 0,
+                                                   QTableWidgetItem(joined_authors))
+            self.ui.journalListTableWidget.setItem(row_position, 1,
+                                                   QTableWidgetItem(title))
+            self.ui.journalListTableWidget.setItem(row_position, 2,
+                                                   QTableWidgetItem(type_))
+            self.ui.journalListTableWidget.setItem(row_position, 3,
+                                                   QTableWidgetItem(date))
+
+    def build_results_table(self: Self) -> None:
         """Build the results table based on the results columns."""
-        queryHeaders = [header for header, query in self.queryColumns]
-        headers = self.publicationColumns + queryHeaders
+        query_headers = [header for header, query in self.queryColumns]
+        headers = self.publicationColumns + query_headers
 
         self.ui.resultsListTableWidget.setColumnCount(len(headers))
         self.ui.resultsListTableWidget.setHorizontalHeaderLabels(headers)
 
-    def addColumn(self):
+    def add_column(self: Self) -> None:
         """Add a column to the results table."""
-        self.queryColumns.append((self.ui.addColumnHeaderEntry.text(), self.ui.addColumnQueryText.toPlainText()))
-        self.buildResultsTable()
+        self.queryColumns.append((self.ui.addColumnHeaderEntry.text(),
+                                  self.ui.addColumnQueryText.toPlainText()))
+        self.build_results_table()
 
-        self.closeAddColumn()
+        self.close_add_column()
 
-    def closeAddColumn(self):
+    def close_add_column(self: Self) -> None:
         """Close the Add Column modal."""
         self.ui.addColumnHeaderEntry.clear()
         self.ui.addColumnQueryText.clear()
         self.ui.addColumnPage.setVisible(False)
 
-    def openEditColumn(self, columnIndex):
+    def open_edit_column(self: Self, column_index: int) -> None:
         """Open the Edit Column modal."""
-        if columnIndex < len(self.publicationColumns):
+        if column_index < len(self.publicationColumns):
             return
 
         self.ui.editColumnPage.setVisible(True)
-        self.editingColumn = columnIndex - len(self.publicationColumns)
+        self.editingColumn = column_index - len(self.publicationColumns)
 
         header, query = self.queryColumns[self.editingColumn]
         self.ui.editColumnHeaderEntry.setText(header)
         self.ui.editColumnQueryText.setPlainText(query)
 
-    def editColumn(self):
+    def edit_column(self: Self) -> None:
         """Edit a column in the results table."""
+        self.queryColumns[self.editingColumn] = (
+            self.ui.editColumnHeaderEntry.text(),
+            self.ui.editColumnQueryText.toPlainText())
+        self.build_results_table()
 
-        self.queryColumns[self.editingColumn] = (self.ui.editColumnHeaderEntry.text(), self.ui.editColumnQueryText.toPlainText())
-        self.buildResultsTable()
+        self.close_edit_column()
 
-        self.closeEditColumn()
-
-    def deleteColumn(self, columnIndex):
+    def delete_column(self: Self, column_index: int) -> None:
         """Delete a column from the results table."""
-        self.queryColumns.pop(columnIndex)
-        self.buildResultsTable()
+        self.queryColumns.pop(column_index)
+        self.build_results_table()
 
-        self.closeEditColumn()
+        self.close_edit_column()
 
-    def closeEditColumn(self):
+    def close_edit_column(self: Self) -> None:
+        """Close the Edit Column modal."""
         self.editingColumn = None
 
         self.ui.editColumnHeaderEntry.clear()
         self.ui.editColumnQueryText.clear()
         self.ui.editColumnPage.setVisible(False)
 
-    def processJournals(self):
-        """Process the uploaded journals using the selected AI model."""
-
-        self.ui.resultsListTableWidget.setRowCount(0)
-
     def process_journals(self: Self) -> None:
         """Process the uploaded journals using the selected AI model."""
+        self.ui.resultsListTableWidget.setRowCount(0)
         # queryText = self.ui.searchResultsBar.text()
 
         for journal in self.uploadedJournals:
             doi = journal.split("/")[-1].replace(".json", "")
             upload_file(journal)
 
-            columnResults = [query_gpt(query) for header, query in self.queryColumns]
+            column_results = [query_gpt(query) for header, query in
+                               self.queryColumns]
             clear_conversation_history()
 
             row_position = self.ui.resultsListTableWidget.rowCount()
             self.ui.resultsListTableWidget.insertRow(row_position)
-            self.ui.resultsListTableWidget.setItem(row_position, 0, QTableWidgetItem(doi))
-            for i, columnResult in enumerate(columnResults):
-                self.ui.resultsListTableWidget.setItem(row_position, i + 1, QTableWidgetItem(columnResult))
+            self.ui.resultsListTableWidget.setItem(
+                row_position,0, QTableWidgetItem(doi))
+            
+            for i, column_result in enumerate(column_results):
+                self.ui.resultsListTableWidget.setItem(
+                    row_position, i + 1,QTableWidgetItem(column_result))
 
     def handle_export(self: Self) -> None:
         """Export the processed journals to an Excel file."""

--- a/road_safety_scanner.py
+++ b/road_safety_scanner.py
@@ -345,9 +345,6 @@ class MainWindow(QMainWindow):
             doi = journal.split("/")[-1].replace(".json", "")
             uploadFile(journal)
 
-            for header, query in self.queryColumns:
-                queryGPT(query)
-
             columnResults = [queryGPT(query) for header, query in self.queryColumns]
             clearConversationHistory()
 

--- a/road_safety_scanner.py
+++ b/road_safety_scanner.py
@@ -305,6 +305,9 @@ class MainWindow(QMainWindow):
 
     def openEditColumn(self, columnIndex):
         """Open the Edit Column modal."""
+        if columnIndex < len(self.publicationColumns):
+            return
+
         self.ui.editColumnPage.setVisible(True)
         self.editingColumn = columnIndex - len(self.publicationColumns)
 

--- a/road_safety_scanner.py
+++ b/road_safety_scanner.py
@@ -340,6 +340,8 @@ class MainWindow(QMainWindow):
     def processJournals(self):
         """Process the uploaded journals using the selected AI model."""
 
+        self.ui.resultsListTableWidget.setRowCount(0)
+
         for journal in self.uploadedJournals:
             doi = journal.split("/")[-1].replace(".json", "")
             uploadFile(journal)

--- a/road_safety_scanner.py
+++ b/road_safety_scanner.py
@@ -3,8 +3,8 @@ import json
 import sys
 from typing import Any, Callable, Self
 
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QMouseEvent, QPainter, QRect
+from PySide6.QtCore import QRect, Qt
+from PySide6.QtGui import QMouseEvent, QPainter
 from PySide6.QtWidgets import (
     QApplication,
     QFileDialog,
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from modules.exporter import exportToExcel, journal_responses_to_data_frame
+from modules.exporter import export_to_excel, journal_responses_to_data_frame
 from modules.GUI import Ui_Dialog
 from modules.journal_downloader.downloader import (
     JOURNALS_PATH,
@@ -406,7 +406,6 @@ class MainWindow(QMainWindow):
     def process_journals(self: Self) -> None:
         """Process the uploaded journals using the selected AI model."""
         self.ui.resultsListTableWidget.setRowCount(0)
-        # queryText = self.ui.searchResultsBar.text()
 
         for journal in self.uploadedJournals:
             doi = journal.split("/")[-1].replace(".json", "")
@@ -434,7 +433,7 @@ class MainWindow(QMainWindow):
         
         if filepath:
             df = journal_responses_to_data_frame(self.ui.resultsListTableWidget)
-            exportToExcel(filepath, df)
+            export_to_excel(filepath, df)
             pass
         pass
 

--- a/road_safety_scanner.py
+++ b/road_safety_scanner.py
@@ -1,9 +1,8 @@
 
 import sys
-from PySide6.QtWidgets import QApplication, QMainWindow, QFileDialog, QTableWidgetItem, QHeaderView
+from PySide6.QtWidgets import QApplication, QMainWindow, QFileDialog, QTableWidgetItem, QHeaderView, QProgressDialog
 from PySide6.QtCore import Qt
 import json
-import sys
 
 from modules.GUI import Ui_Dialog
 from modules.journal_downloader.downloader import JOURNALS_PATH, downloadJournals


### PR DESCRIPTION
## Description of changes
Adds the query defined columns feature:
- Setting, type, population, and summary have been turned into query-defined columns
- 'Add column' can allow a user to add query-defined columns
- Query-defined columns can be clicked on to open an editing menu where their query and header can be modified
- Persisting query-defined columns has not been implemented yet, and is not part of this ticket- but is part of the user story

Issue number: #33 
## Screenshots
<img width="863" alt="Screenshot 2024-09-23 at 9 15 14 PM" src="https://github.com/user-attachments/assets/968f7fdb-d72f-4ef7-98b9-595c389f3530">
<img width="863" alt="Screenshot 2024-09-23 at 9 18 26 PM" src="https://github.com/user-attachments/assets/f47c1b18-8402-4b16-a254-e52206cc5cb4">
