### PR TITLE
feat: added journal search loading indicator

### DIFF
--- a/modules/journal_downloader/__init__.py
+++ b/modules/journal_downloader/__init__.py
@@ -1,3 +1,4 @@
 from .downloader import downloadJournal, downloadJournals, getJournals, getJournal, clearJournals
+from .signal import QueryElsevierThread
 
-__all__ = ['downloadJournal', 'downloadJournals', 'getJournals', 'getJournal', 'clearJournals']
+__all__ = ['downloadJournal', 'downloadJournals', 'getJournals', 'getJournal', 'clearJournals', 'QueryElsevierThread']

--- a/modules/journal_downloader/downloader.py
+++ b/modules/journal_downloader/downloader.py
@@ -17,29 +17,6 @@ class QueryElsevierResult:
         self.author = author
         self.date = date
 
-def queryElsevier(api_key: str, query: str, limit=25, wait=0.05) -> list[QueryElsevierResult]:
-    """
-    Queries the Elsevier API.
-    """
-
-    query = urllib.parse.quote(query)
-
-    request = urllib.request.Request(f"{elsevierAPI}/search/scopus?query={query}", headers={'Accept': 'application/json', 'X-ELS-APIKey': api_key})
-
-    # Read all journals from the query until limit is hit
-    results = []
-    totalResults = 1
-    while (len(results) < limit and len(results) < totalResults):
-        request = urllib.request.Request(f"{elsevierAPI}/search/scopus?query={query}&start={len(results)}", headers={'Accept': 'application/json', 'X-ELS-APIKey': api_key})
-        
-        searchedJournals = json.loads(urllib.request.urlopen(request).read().decode('utf-8'))
-        totalResults = int(searchedJournals["search-results"]["opensearch:totalResults"])
-
-        results.extend([QueryElsevierResult(journal["prism:doi"], journal["dc:title"], journal["dc:creator"], journal["prism:coverDisplayDate"]) for journal in searchedJournals["search-results"]["entry"]])
-        time.sleep(wait)
-
-    return results
-
 def downloadJournal(api_key: str, doi: str) -> Any:
     """
     Downloads a journal from the Elsevier API.

--- a/modules/journal_downloader/signal.py
+++ b/modules/journal_downloader/signal.py
@@ -1,0 +1,39 @@
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from PySide6.QtCore import QThread, Signal
+
+from modules.journal_downloader.downloader import QueryElsevierResult, elsevierAPI
+
+class QueryElsevierThread(QThread):
+    progressSignal = Signal(int)
+    finishedSignal = Signal(object)
+
+    def __init__(self, apiKey, query, parent=None, limit=100, wait=0.05):
+        super().__init__(parent)
+        self.apiKey = apiKey
+        self.query = query
+        self.limit = limit
+        self.wait = wait
+
+    def run(self):
+        query = urllib.parse.quote(self.query)
+        request = urllib.request.Request(f"{elsevierAPI}/search/scopus?query={query}", headers={'Accept': 'application/json', 'X-ELS-APIKey': self.apiKey})
+
+        # Read all journals from the query until limit is hit
+        results = []
+        totalResults = int(json.loads(urllib.request.urlopen(request).read().decode('utf-8'))["search-results"]["opensearch:totalResults"])
+        
+        while (len(results) < self.limit and len(results) < totalResults):
+            request = urllib.request.Request(f"{elsevierAPI}/search/scopus?query={query}&start={len(results)}", headers={'Accept': 'application/json', 'X-ELS-APIKey': self.apiKey})
+            
+            searchedJournals = json.loads(urllib.request.urlopen(request).read().decode('utf-8'))
+            results.extend([QueryElsevierResult(journal["prism:doi"], journal["dc:title"], journal["dc:creator"], journal["prism:coverDisplayDate"]) for journal in searchedJournals["search-results"]["entry"]])
+            
+            self.progressSignal.emit(int(len(results) / self.limit * 100))
+            time.sleep(self.wait)
+
+        self.finishedSignal.emit(results)


### PR DESCRIPTION
## Description of changes
Adds the search bar tweaks mentioned in Sprint 2 retrospective:
- Modifies the search bar to use TITLE-ABS-KEY instead of TITLE. Documentation on it here: https://dev.elsevier.com/sc_search_tips.html
- Adds loading progress indicators to the journal searcher.
- Have not added loading progress indicators to the results page. With #38, it will cause conflicts if implemented before merged, so will wait until after.

Issue number: #32
## Screenshots
<img width="874" alt="Screenshot 2024-09-23 at 10 57 05 PM" src="https://github.com/user-attachments/assets/4b6265c4-06d8-4998-a1e2-5228a159eda4">
