### PR TITLE
chore: set up ruff linter rules

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "charliermarsh.ruff",
+        "tamasfe.even-better-toml"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,12 @@
 {
     "cSpell.words": [
-        "Elsevier"
+        "AFFILCOUNTRY",
+        "coredata",
+        "dataframe",
+        "dois",
+        "Elsevier",
+        "opensearch",
+        "REFPUBYEAR",
+        "scopus"
     ]
 }

--- a/modules/GUI/__init__.py
+++ b/modules/GUI/__init__.py
@@ -1,3 +1,5 @@
+"""Defines the module's public interface."""
+
 from .gui import Ui_Dialog
 
 __all__ = ['Ui_Dialog']

--- a/modules/GUI/__init__.py
+++ b/modules/GUI/__init__.py
@@ -2,4 +2,4 @@
 
 from .gui import Ui_Dialog
 
-__all__ = ['Ui_Dialog']
+__all__ = ["Ui_Dialog"]

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -2,4 +2,4 @@
 
 from . import GUI, exporter, journal_downloader, keys, llm
 
-__all__ = ['exporter', 'GUI', 'journal_downloader', 'keys', 'llm']
+__all__ = ["exporter", "GUI", "journal_downloader", "keys", "llm"]

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,3 +1,5 @@
-from . import exporter, GUI, journal_downloader, keys, llm
+"""Defines the public interface for all modules."""
+
+from . import GUI, exporter, journal_downloader, keys, llm
 
 __all__ = ['exporter', 'GUI', 'journal_downloader', 'keys', 'llm']

--- a/modules/exporter/__init__.py
+++ b/modules/exporter/__init__.py
@@ -3,4 +3,4 @@
 from .exporter import exportToExcel
 from .journal_parser import journalResponsesToDataFrame
 
-__all__ = ['exportToExcel', 'journalResponsesToDataFrame']
+__all__ = ["exportToExcel", "journalResponsesToDataFrame"]

--- a/modules/exporter/__init__.py
+++ b/modules/exporter/__init__.py
@@ -1,6 +1,6 @@
 """Defines the module's public interface."""
 
-from .exporter import exportToExcel
-from .journal_parser import journalResponsesToDataFrame
+from .exporter import export_to_excel
+from .journal_parser import journal_responses_to_data_frame
 
-__all__ = ["exportToExcel", "journalResponsesToDataFrame"]
+__all__ = ["export_to_excel", "journal_responses_to_data_frame"]

--- a/modules/exporter/__init__.py
+++ b/modules/exporter/__init__.py
@@ -1,3 +1,5 @@
+"""Defines the module's public interface."""
+
 from .exporter import exportToExcel
 from .journal_parser import journalResponsesToDataFrame
 

--- a/modules/exporter/exporter.py
+++ b/modules/exporter/exporter.py
@@ -1,7 +1,8 @@
+"""Utility functions for exporting data to various formats."""
+
 from pandas import DataFrame
 
+
 def exportToExcel(outputFileName: str, dataframe: DataFrame) -> None:
-    """
-    Exports a DataFrame to an Excel file
-    """
+    """Export a DataFrame to an Excel file."""
     dataframe.to_excel(outputFileName, index=False)

--- a/modules/exporter/exporter.py
+++ b/modules/exporter/exporter.py
@@ -3,6 +3,6 @@
 from pandas import DataFrame
 
 
-def exportToExcel(outputFileName: str, dataframe: DataFrame) -> None:
+def export_to_excel(output_file_name: str, dataframe: DataFrame) -> None:
     """Export a DataFrame to an Excel file."""
-    dataframe.to_excel(outputFileName, index=False)
+    dataframe.to_excel(output_file_name, index=False)

--- a/modules/exporter/journal_parser.py
+++ b/modules/exporter/journal_parser.py
@@ -20,5 +20,4 @@ def journalResponsesToDataFrame(table: QTableWidget) -> DataFrame:
                 row_data.append(item.text())
         data.append(row_data)
     headers = [table.horizontalHeaderItem(i).text() for i in range(col_count)]
-    df = DataFrame(data, columns=headers)
-    return df
+    return DataFrame(data, columns=headers)

--- a/modules/exporter/journal_parser.py
+++ b/modules/exporter/journal_parser.py
@@ -1,10 +1,11 @@
-from typing import Any
-from pandas import DataFrame
+"""Utility functions for parsing journal responses."""
 
-def journalResponsesToDataFrame(table: Any) -> DataFrame:
-    """
-    Convert a list of journals with responses to a pandas DataFrame
-    """
+from pandas import DataFrame
+from PySide6.QtWidgets import QTableWidget
+
+
+def journalResponsesToDataFrame(table: QTableWidget) -> DataFrame:
+    """Convert a list of journals with responses to a pandas DataFrame."""
     data = []
     row_count = table.rowCount()
     col_count = table.columnCount()

--- a/modules/exporter/journal_parser.py
+++ b/modules/exporter/journal_parser.py
@@ -4,7 +4,7 @@ from pandas import DataFrame
 from PySide6.QtWidgets import QTableWidget
 
 
-def journalResponsesToDataFrame(table: QTableWidget) -> DataFrame:
+def journal_responses_to_data_frame(table: QTableWidget) -> DataFrame:
     """Convert a list of journals with responses to a pandas DataFrame."""
     data = []
     row_count = table.rowCount()

--- a/modules/journal_downloader/__init__.py
+++ b/modules/journal_downloader/__init__.py
@@ -1,12 +1,13 @@
 """Defines the module's public interface."""
 from .downloader import (
-    clearJournals,
-    downloadJournal,
-    downloadJournals,
-    getJournal,
-    getJournals,
+    clear_journals,
+    download_journal,
+    download_journals,
+    get_journal,
+    get_journals,
 )
 from .signal import QueryElsevierThread
 
-__all__ = ["downloadJournal", "downloadJournals", "getJournals", "getJournal",
-           "clearJournals", "QueryElsevierThread"]
+__all__ = ["download_journal", "download_journals",
+           "get_journals", "get_journal",
+           "clear_journals", "QueryElsevierThread"]

--- a/modules/journal_downloader/__init__.py
+++ b/modules/journal_downloader/__init__.py
@@ -8,5 +8,5 @@ from .downloader import (
 )
 from .signal import QueryElsevierThread
 
-__all__ = ['downloadJournal', 'downloadJournals', 'getJournals', 'getJournal',
-           'clearJournals', 'QueryElsevierThread']
+__all__ = ["downloadJournal", "downloadJournals", "getJournals", "getJournal",
+           "clearJournals", "QueryElsevierThread"]

--- a/modules/journal_downloader/__init__.py
+++ b/modules/journal_downloader/__init__.py
@@ -1,4 +1,12 @@
-from .downloader import downloadJournal, downloadJournals, getJournals, getJournal, clearJournals
+"""Defines the module's public interface."""
+from .downloader import (
+    clearJournals,
+    downloadJournal,
+    downloadJournals,
+    getJournal,
+    getJournals,
+)
 from .signal import QueryElsevierThread
 
-__all__ = ['downloadJournal', 'downloadJournals', 'getJournals', 'getJournal', 'clearJournals', 'QueryElsevierThread']
+__all__ = ['downloadJournal', 'downloadJournals', 'getJournals', 'getJournal',
+           'clearJournals', 'QueryElsevierThread']

--- a/modules/journal_downloader/downloader.py
+++ b/modules/journal_downloader/downloader.py
@@ -31,7 +31,7 @@ def queryElsevier(api_key: str, query: str,
 
     request = urllib.request.Request(
         f"{elsevierAPI}/search/scopus?query={query}",
-        headers={'Accept': 'application/json', 'X-ELS-APIKey': api_key})
+        headers={"Accept": "application/json", "X-ELS-APIKey": api_key})
 
     # Read all journals from the query until limit is hit
     results = []
@@ -39,10 +39,10 @@ def queryElsevier(api_key: str, query: str,
     while (len(results) < limit and len(results) < totalResults):
         request = urllib.request.Request(
             f"{elsevierAPI}/search/scopus?query={query}&start={len(results)}",
-            headers={'Accept': 'application/json', 'X-ELS-APIKey': api_key})
+            headers={"Accept": "application/json", "X-ELS-APIKey": api_key})
         
         searchedJournals = json.loads(
-            urllib.request.urlopen(request).read().decode('utf-8'))
+            urllib.request.urlopen(request).read().decode("utf-8"))
         totalResults = int(
             searchedJournals["search-results"]["opensearch:totalResults"])
 
@@ -60,8 +60,8 @@ def queryElsevier(api_key: str, query: str,
 def downloadJournal(api_key: str, doi: str) -> dict[str, Any]:
     """Download a journal from the Elsevier API."""
     request = urllib.request.Request(f"{elsevierAPI}/article/doi/${doi}",
-                headers={'Accept': 'application/json', 'X-ELS-APIKey': api_key})
-    journal = urllib.request.urlopen(request).read().decode('utf-8')
+                headers={"Accept": "application/json", "X-ELS-APIKey": api_key})
+    journal = urllib.request.urlopen(request).read().decode("utf-8")
 
     with open(f"{JOURNALS_PATH}/{doi.replace('/', '-')}.json",
               "w", encoding="utf-8") as f:

--- a/modules/journal_downloader/downloader.py
+++ b/modules/journal_downloader/downloader.py
@@ -1,45 +1,89 @@
+"""Utility functions for downloading journals from Elsevier."""
+
 import json
 import os
 import time
-from typing import Any
 import urllib.error
 import urllib.parse
 import urllib.request
+from typing import Any, Self
 
 elsevierAPI = "https://api.elsevier.com/content"
 
 JOURNALS_PATH = f"{os.path.dirname(os.path.abspath(__file__))}/journals"
 
 class QueryElsevierResult:
-    def __init__(self, doi: str, title: str, author: str, date: str) -> None:
+    """A result from a query to the Elsevier API."""
+
+    def __init__(self: Self, doi: str, title: str,
+                 author: str, date: str) -> None:
+        """Initialize the QueryElsevierResult."""
         self.doi = doi
         self.title = title
         self.author = author
         self.date = date
 
-def downloadJournal(api_key: str, doi: str) -> Any:
-    """
-    Downloads a journal from the Elsevier API.
-    """
-    
-    request = urllib.request.Request(f"{elsevierAPI}/article/doi/${doi}", headers={'Accept': 'application/json', 'X-ELS-APIKey': api_key})
+def queryElsevier(api_key: str, query: str,
+                  limit: float = 25,
+                  wait: float = 0.05) -> list[QueryElsevierResult]:
+    """Query the Elsevier API."""
+    query = urllib.parse.quote(query)
+
+    request = urllib.request.Request(
+        f"{elsevierAPI}/search/scopus?query={query}",
+        headers={'Accept': 'application/json', 'X-ELS-APIKey': api_key})
+
+    # Read all journals from the query until limit is hit
+    results = []
+    totalResults = 1
+    while (len(results) < limit and len(results) < totalResults):
+        request = urllib.request.Request(
+            f"{elsevierAPI}/search/scopus?query={query}&start={len(results)}",
+            headers={'Accept': 'application/json', 'X-ELS-APIKey': api_key})
+        
+        searchedJournals = json.loads(
+            urllib.request.urlopen(request).read().decode('utf-8'))
+        totalResults = int(
+            searchedJournals["search-results"]["opensearch:totalResults"])
+
+        results.extend([
+            QueryElsevierResult(journal["prism:doi"],
+                                journal["dc:title"],
+                                journal["dc:creator"], 
+                                journal["prism:coverDisplayDate"])
+                    for journal in searchedJournals["search-results"]["entry"]])
+        
+        time.sleep(wait)
+
+    return results
+
+def downloadJournal(api_key: str, doi: str) -> dict[str, Any]:
+    """Download a journal from the Elsevier API."""
+    request = urllib.request.Request(f"{elsevierAPI}/article/doi/${doi}",
+                headers={'Accept': 'application/json', 'X-ELS-APIKey': api_key})
     journal = urllib.request.urlopen(request).read().decode('utf-8')
 
-    with open(f"{JOURNALS_PATH}/{doi.replace('/', '-')}.json", "w", encoding="utf-8") as f:
+    with open(f"{JOURNALS_PATH}/{doi.replace('/', '-')}.json",
+              "w", encoding="utf-8") as f:
         f.write(journal)
 
     return json.loads(journal)
 
 class DownloadJournalsResult:
-    def __init__(self, results: list[dict[str, Any]], errors: list[dict[str, str]]) -> None:
+    """A result from downloading journals from the Elsevier API."""
+    
+    def __init__(self: Self, results: list[dict[str, Any]],
+                 errors: list[dict[str, str]]) -> None:
+        """Initialize the DownloadJournalsResult."""
         self.results = results
         self.errors = errors
 
-def downloadJournals(api_key: str, dois: list[str], wait=0.05) -> DownloadJournalsResult:
-    """
-    Downloads journals from the internet. Should store previous queries run to avoid repetition.
-    """
+def downloadJournals(api_key: str, dois: list[str],
+                     wait: float = 0.05) -> DownloadJournalsResult:
+    """Download journals from the internet.
 
+    Should store previous queries run to avoid repetition.
+    """
     if not os.path.exists(JOURNALS_PATH):
         os.makedirs(JOURNALS_PATH)
 
@@ -56,29 +100,20 @@ def downloadJournals(api_key: str, dois: list[str], wait=0.05) -> DownloadJourna
 
 
 def getJournals() -> list[Any]:
-    """
-    Returns the journals in the journals directory.
-    """
-
+    """Return the journals in the journals directory."""
     journals = []
     for journal in os.listdir("journals"):
-        with open(f"{JOURNALS_PATH}/journals/{journal}", "r", encoding="utf-8") as f:
+        with open(f"{JOURNALS_PATH}/journals/{journal}") as f:
             journals.append(json.load(f))
 
     return journals
 
-def getJournal(path: str) -> Any:
-    """
-    Returns a journal from the journals directory.
-    """
-
-    with open(path, "r", encoding="utf-8") as f:
+def getJournal(path: str) -> dict[str, Any]:
+    """Return a journal from the journals directory."""
+    with open(path) as f:
         return json.load(f)
 
 def clearJournals() -> None:
-    """
-    Clears the journals in the journals directory.
-    """
-
+    """Clear the journals in the journals directory."""
     for journal in os.listdir("journals"):
         os.remove(f"journals/{journal}")

--- a/modules/journal_downloader/signal.py
+++ b/modules/journal_downloader/signal.py
@@ -35,21 +35,21 @@ class QueryElsevierThread(QThread):
         query = urllib.parse.quote(self.query)
         request = urllib.request.Request(
             f"{elsevierAPI}/search/scopus?query={query}",
-            headers={'Accept': 'application/json', 'X-ELS-APIKey': self.apiKey})
+            headers={"Accept": "application/json", "X-ELS-APIKey": self.apiKey})
 
         # Read all journals from the query until limit is hit
         results = []
         totalResults = int(json.loads(
-            urllib.request.urlopen(request).read().decode('utf-8'))["search-results"]["opensearch:totalResults"])
+            urllib.request.urlopen(request).read().decode("utf-8"))["search-results"]["opensearch:totalResults"])
         
         while (len(results) < self.limit and len(results) < totalResults):
             request = urllib.request.Request(
                 f"{elsevierAPI}/search/scopus?query={query}&start={len(results)}",
-                  headers={'Accept': 'application/json',
-                           'X-ELS-APIKey': self.apiKey})
+                  headers={"Accept": "application/json",
+                           "X-ELS-APIKey": self.apiKey})
             
             searchedJournals = json.loads(
-                urllib.request.urlopen(request).read().decode('utf-8'))
+                urllib.request.urlopen(request).read().decode("utf-8"))
             results.extend([
                 QueryElsevierResult(journal["prism:doi"],
                                     journal["dc:title"],

--- a/modules/journal_downloader/signal.py
+++ b/modules/journal_downloader/signal.py
@@ -1,37 +1,62 @@
+"""Signals for updating the query progress bar in the GUI."""
+
 import json
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from typing import Self
 
 from PySide6.QtCore import QThread, Signal
 
-from modules.journal_downloader.downloader import QueryElsevierResult, elsevierAPI
+from modules.journal_downloader.downloader import (
+    QueryElsevierResult,
+    elsevierAPI,
+)
+
 
 class QueryElsevierThread(QThread):
+    """A thread for querying the Elsevier API with progress updates."""
+    
     progressSignal = Signal(int)
     finishedSignal = Signal(object)
 
-    def __init__(self, apiKey, query, parent=None, limit=100, wait=0.05):
-        super().__init__(parent)
+    def __init__(self: Self, apiKey: str, query: str,
+                 limit:int=100, wait:float=0.05) -> None:
+        """Initialize the QueryElsevierThread."""
+        super().__init__(None)
         self.apiKey = apiKey
         self.query = query
         self.limit = limit
         self.wait = wait
 
-    def run(self):
+    def run(self: Self) -> None:
+        """Query the Elsevier API with progress updates."""
         query = urllib.parse.quote(self.query)
-        request = urllib.request.Request(f"{elsevierAPI}/search/scopus?query={query}", headers={'Accept': 'application/json', 'X-ELS-APIKey': self.apiKey})
+        request = urllib.request.Request(
+            f"{elsevierAPI}/search/scopus?query={query}",
+            headers={'Accept': 'application/json', 'X-ELS-APIKey': self.apiKey})
 
         # Read all journals from the query until limit is hit
         results = []
-        totalResults = int(json.loads(urllib.request.urlopen(request).read().decode('utf-8'))["search-results"]["opensearch:totalResults"])
+        totalResults = int(json.loads(
+            urllib.request.urlopen(request).read().decode('utf-8'))["search-results"]["opensearch:totalResults"])
         
         while (len(results) < self.limit and len(results) < totalResults):
-            request = urllib.request.Request(f"{elsevierAPI}/search/scopus?query={query}&start={len(results)}", headers={'Accept': 'application/json', 'X-ELS-APIKey': self.apiKey})
+            request = urllib.request.Request(
+                f"{elsevierAPI}/search/scopus?query={query}&start={len(results)}",
+                  headers={'Accept': 'application/json',
+                           'X-ELS-APIKey': self.apiKey})
             
-            searchedJournals = json.loads(urllib.request.urlopen(request).read().decode('utf-8'))
-            results.extend([QueryElsevierResult(journal["prism:doi"], journal["dc:title"], journal["dc:creator"], journal["prism:coverDisplayDate"]) for journal in searchedJournals["search-results"]["entry"]])
+            searchedJournals = json.loads(
+                urllib.request.urlopen(request).read().decode('utf-8'))
+            results.extend([
+                QueryElsevierResult(journal["prism:doi"],
+                                    journal["dc:title"],
+                                    journal["dc:creator"],
+                                    journal["prism:coverDisplayDate"])
+                                    for journal in 
+                                    searchedJournals["search-results"]["entry"]])
             
             self.progressSignal.emit(int(len(results) / self.limit * 100))
             time.sleep(self.wait)

--- a/modules/keys/__init__.py
+++ b/modules/keys/__init__.py
@@ -1,5 +1,5 @@
 """Defines the module's public interface."""
 
-from .keys import loadKeys, setKey
+from .keys import load_keys, set_key
 
-__all__ = ["loadKeys", "setKey"]
+__all__ = ["load_keys", "set_key"]

--- a/modules/keys/__init__.py
+++ b/modules/keys/__init__.py
@@ -2,4 +2,4 @@
 
 from .keys import loadKeys, setKey
 
-__all__ = ['loadKeys', 'setKey']
+__all__ = ["loadKeys", "setKey"]

--- a/modules/keys/__init__.py
+++ b/modules/keys/__init__.py
@@ -1,3 +1,5 @@
+"""Defines the module's public interface."""
+
 from .keys import loadKeys, setKey
 
 __all__ = ['loadKeys', 'setKey']

--- a/modules/keys/keys.py
+++ b/modules/keys/keys.py
@@ -7,7 +7,7 @@ KEYS_PATH = f"{os.path.dirname(os.path.abspath(__file__))}/keys.json"
 
 keys = {}
 
-def loadKeys() -> dict[str, str]:
+def load_keys() -> dict[str, str]:
     """Load the keys file."""
     global keys
 
@@ -19,7 +19,7 @@ def loadKeys() -> dict[str, str]:
 
     return keys
 
-def setKey(key: str, value: str) -> None:
+def set_key(key: str, value: str) -> None:
     """Set a key in the keys file."""
     keys[key] = value
 

--- a/modules/keys/keys.py
+++ b/modules/keys/keys.py
@@ -1,3 +1,5 @@
+"""Utility functions for the keys module."""
+
 import json
 import os
 
@@ -12,14 +14,13 @@ def loadKeys() -> dict[str, str]:
     if not os.path.exists(KEYS_PATH):
         return
     
-    with open(KEYS_PATH, 'r', encoding='utf-8') as f:
+    with open(KEYS_PATH) as f:
         keys = json.load(f)
 
     return keys
 
 def setKey(key: str, value: str) -> None:
-    """Sets a key in the keys file."""
-
+    """Set a key in the keys file."""
     keys[key] = value
 
     with open(KEYS_PATH, 'w', encoding='utf-8') as f:

--- a/modules/keys/keys.py
+++ b/modules/keys/keys.py
@@ -3,7 +3,7 @@
 import json
 import os
 
-KEYS_PATH = f'{os.path.dirname(os.path.abspath(__file__))}/keys.json'
+KEYS_PATH = f"{os.path.dirname(os.path.abspath(__file__))}/keys.json"
 
 keys = {}
 
@@ -23,5 +23,5 @@ def setKey(key: str, value: str) -> None:
     """Set a key in the keys file."""
     keys[key] = value
 
-    with open(KEYS_PATH, 'w', encoding='utf-8') as f:
+    with open(KEYS_PATH, "w", encoding="utf-8") as f:
         json.dump(keys, f, indent=4)

--- a/modules/keys/keys.py
+++ b/modules/keys/keys.py
@@ -12,7 +12,7 @@ def loadKeys() -> dict[str, str]:
     global keys
 
     if not os.path.exists(KEYS_PATH):
-        return
+        return None
     
     with open(KEYS_PATH) as f:
         keys = json.load(f)

--- a/modules/llm/__init__.py
+++ b/modules/llm/__init__.py
@@ -2,4 +2,4 @@
 
 from .gpt.query import clearConversationHistory, queryGPT, uploadFile
 
-__all__ = ['uploadFile', 'queryGPT', 'clearConversationHistory']
+__all__ = ["uploadFile", "queryGPT", "clearConversationHistory"]

--- a/modules/llm/__init__.py
+++ b/modules/llm/__init__.py
@@ -1,3 +1,5 @@
-from .gpt.query import uploadFile, queryGPT, clearConversationHistory
+"""Defines the module's public interface."""
+
+from .gpt.query import clearConversationHistory, queryGPT, uploadFile
 
 __all__ = ['uploadFile', 'queryGPT', 'clearConversationHistory']

--- a/modules/llm/__init__.py
+++ b/modules/llm/__init__.py
@@ -1,5 +1,5 @@
 """Defines the module's public interface."""
 
-from .gpt.query import clearConversationHistory, queryGPT, uploadFile
+from .gpt.query import clear_conversation_history, query_gpt, upload_file
 
-__all__ = ["uploadFile", "queryGPT", "clearConversationHistory"]
+__all__ = ["upload_file", "query_gpt", "clear_conversation_history"]

--- a/modules/llm/gpt/query.py
+++ b/modules/llm/gpt/query.py
@@ -8,15 +8,15 @@ from openai import OpenAI
 
 client = None
 
-def setupClient(apiKey: str) -> None:
+def setup_client(api_key: str) -> None:
     """Set up the OpenAI client with the provided API key."""
     global client
-    client = OpenAI(api_key=apiKey)
+    client = OpenAI(api_key=api_key)
 
 conversation_history = []
 
 # Function to extract text from a PDF file
-def extractTextFromPdf(file_path: str) -> str:
+def extract_text_from_pdf(file_path: str) -> str:
     """Extract text from a PDF file using pdfplumber."""
     try:
         text = ""
@@ -28,7 +28,7 @@ def extractTextFromPdf(file_path: str) -> str:
         print(f"There was an issue extracting text from the PDF file: {e}")
         return ""
 
-def uploadFile(file_path: str) -> None:
+def upload_file(file_path: str) -> None:
     """Upload file to the GPT model and store the content."""
     try:        
         # Check the file extension
@@ -44,7 +44,7 @@ def uploadFile(file_path: str) -> None:
                                                 {}).get("originalText")
         elif file_extension == ".pdf":
             # Extract text from the PDF file
-            file_content = extractTextFromPdf(file_path)
+            file_content = extract_text_from_pdf(file_path)
         else:
             print("Unsupported file type. Please upload a .json or .pdf file.")
             return
@@ -77,7 +77,7 @@ def uploadFile(file_path: str) -> None:
         print(f"There was an issue uploading the file content: {e}")
 
 
-def queryGPT(user_query: str) -> str:
+def query_gpt(user_query: str) -> str:
     """Query the GPT model with the user input and return the response."""
     try:
         # Add the user query to the conversation history
@@ -100,7 +100,7 @@ def queryGPT(user_query: str) -> str:
     except Exception as e:
         print(f"There was an issue querying the GPT model: {e}")
 
-def clearConversationHistory() -> None:
+def clear_conversation_history() -> None:
     """Clear the conversation history."""
     global conversation_history
     conversation_history = []

--- a/modules/llm/gpt/query.py
+++ b/modules/llm/gpt/query.py
@@ -1,5 +1,8 @@
+"""Utility functions to interact with the GPT model using OpenAI's API."""
+
 import json
 import os
+
 import pdfplumber
 from openai import OpenAI
 
@@ -26,6 +29,7 @@ def extractTextFromPdf(file_path: str) -> str:
         return ""
 
 def uploadFile(file_path: str) -> None:
+    """Upload file to the GPT model and store the content."""
     try:        
         # Check the file extension
         file_extension = os.path.splitext(file_path)[1].lower()
@@ -35,8 +39,9 @@ def uploadFile(file_path: str) -> None:
         
         if file_extension == ".json":
             # Open and read the json file content
-            with open(file_path, 'r', encoding='utf-8') as f:
-                file_content = json.load(f).get("full-text-retrieval-response", {}).get("originalText")
+            with open(file_path) as f:
+                file_content = json.load(f).get("full-text-retrieval-response",
+                                                {}).get("originalText")
         elif file_extension == ".pdf":
             # Extract text from the PDF file
             file_content = extractTextFromPdf(file_path)
@@ -45,8 +50,10 @@ def uploadFile(file_path: str) -> None:
             return
 
         # Add the system and user messages to the conversation history
-        conversation_history.append({"role": "system", "content": "You are uploading an academic journal."})
-        conversation_history.append({"role": "user", "content": f"Please remember the following content: {file_content}"})
+        conversation_history.append({"role": "system",
+                        "content": "You are uploading an academic journal."})
+        conversation_history.append({"role": "user",
+        "content": f"Please remember the following content: {file_content}"})
         
         # Store the file content using OpenAI's API
         response = client.chat.completions.create(
@@ -58,7 +65,8 @@ def uploadFile(file_path: str) -> None:
         response_content = response.choices[0].message.content.strip()
         
         # Add the assistant's response to the conversation history
-        conversation_history.append({"role": "assistant", "content": response_content})
+        conversation_history.append({"role": "assistant",
+                                     "content": response_content})
         
         # Check for successful completion
         if response_content:

--- a/road_safety_scanner.py
+++ b/road_safety_scanner.py
@@ -253,7 +253,7 @@ class MainWindow(QMainWindow):
         for file_name in file_names:
 
             # Check if the file extension is .json
-            if not file_name.endswith('.json'):
+            if not file_name.endswith(".json"):
                 continue
 
             # Open and read the JSON file

--- a/road_safety_scanner.py
+++ b/road_safety_scanner.py
@@ -230,13 +230,13 @@ class MainWindow(QMainWindow):
         if clicked_button == self.ui.pushButton_ChatGpt:
             return
             # set_llm_api_key("GPT_API_KEY")
-        elif clicked_button == self.ui.pushButton_Llama70b:
+        if clicked_button == self.ui.pushButton_Llama70b:
             return
             # set_llm_api_key("LLAMA70B_API_KEY")
-        elif clicked_button == self.ui.pushButton_Llama405b:
+        if clicked_button == self.ui.pushButton_Llama405b:
             return
             # set_llm_api_key("LLAMA405B_API_KEY_")
-        elif clicked_button == self.ui.pushButton_ClaudeSonnet:
+        if clicked_button == self.ui.pushButton_ClaudeSonnet:
             return
             # set_llm_api_key("CLAUDE_SONNET_API_KEY_")
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,4 +7,4 @@ exclude = [
 ]
 
 [lint]
-extend-select = ["E501", "I001", "N801", "N807", "N811", "N812", "N813", "N814", "N999", "D", "UP", "YTT", "ANN", "Q", "RET", "SIM"]
+extend-select = ["E501", "I001", "N", "D", "UP", "YTT", "ANN", "Q", "RET", "SIM"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,4 +7,4 @@ exclude = [
 ]
 
 [lint]
-extend-select = ["E501", "I001", "N801", "N807", "N811", "N812", "N813", "N814", "N999", "D", "UP", "YTT", "ANN"]
+extend-select = ["E501", "I001", "N801", "N807", "N811", "N812", "N813", "N814", "N999", "D", "UP", "YTT", "ANN", "Q"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,4 +7,4 @@ exclude = [
 ]
 
 [lint]
-extend-select = ["E501", "I001", "N801", "N807", "N811", "N812", "N813", "N814", "N999", "D", "UP", "YTT", "ANN", "Q"]
+extend-select = ["E501", "I001", "N801", "N807", "N811", "N812", "N813", "N814", "N999", "D", "UP", "YTT", "ANN", "Q", "RET", "SIM"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,3 +1,10 @@
+# https://docs.astral.sh/ruff/settings/
+
+line-length = 80
+
 exclude = [
     "modules/GUI/gui.py",
 ]
+
+[lint]
+extend-select = ["E501", "I001", "N801", "N807", "N811", "N812", "N813", "N814", "N999", "D", "UP", "YTT", "ANN"]


### PR DESCRIPTION
## Description of changes
Adds linting rules to the ruff.toml and applies them to the project:
- E501: Line length limit (Set to 80)
- I001: Import order sorting
- N801: PEP class names
- N807: Make sure 'dunder' functions (Ones that begin and end with two underscores, like __init__) are documented
- N811, N812, N813, N814: To do with preventing renaming imported items
- N999: Ensure module names have snake case
- D: Set of rules for writing pydocs
- UP: Set of rules to make sure code is being written in the fashion of newer versions like Python 3.10+.
- YTT: Set of rules for making sure code is being written in the fashion of newer versions like Python 3.10+. Seems to mainly apply to certain calls with the sys module.
- ANN: Enforces type annotations on functions.
- Q: Enforces python quote methodology
- RET: Specifies rules around return functions
- SIM: Simplifies code (collapsing if statements, etc)
- Adds recommended extensions to VS code settings.
- Adds words to VS code dictionary to prevent them being raised as 'Problems'

Full supported rule list here: https://docs.astral.sh/ruff/rules/
Open for discussion on what should/shoudn't be included.

Issue number: #36 